### PR TITLE
Add re-export for async_std::path module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .docker-cargo
 target-docker
 .vscode/tasks.json
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "b90eb1dec02087df472ab9f0db65f27edaa654a746830042688bcc2eaf68090f"
 
 [[package]]
 name = "flv-future-aio"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "async-lock",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flv-future-aio"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2018"
 authors = ["fluvio.io"]
 description = "I/O futures for Fluvio project"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@ pub mod zero_copy;
 
 pub mod net;
 
+#[cfg(feature = "asyncstd")]
+pub mod path {
+    pub use async_std::path::*;
+}
 
 pub mod bytes {
     pub use bytes::Bytes;


### PR DESCRIPTION
As discovered in [this issue](https://github.com/infinyon/fluvio/pull/157#discussion_r471765331), we were not previously re-exporting the `async_std::path` module, meaning that we couldn't provide `Path`'s for functions such as `fs::write` which were re-exported. This PR adds the necessary re-export and bumps a minor version.