### PR TITLE
Use 'thiserror' for error::Error impl of SendFileError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "5c85295147490b8fcf2ea3d104080a105a8b2c63f9c319e82c02d8e952388919"
 
 [[package]]
 name = "fluvio-future"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-fs",
  "async-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "pin-project",
  "pin-utils",
  "rustls",
+ "thiserror",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -775,6 +776,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["fluvio.io"]
 description = "I/O futures for Fluvio project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ async-trait = { version = "0.1.40", optional = true }
 rustls = { version = "0.18.0", features = ["dangerous_configuration"], optional = true }
 webpki = { version = "0.21", optional = true }
 async-tls = { version = "0.10.0", optional = true }
+thiserror = "1.0.20"
 fluvio-test-derive = { path = "async-test-derive", version = "0.1.0", optional = true }
 
 

--- a/src/zero_copy.rs
+++ b/src/zero_copy.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::Error as IoError;
-
 use std::os::unix::io::AsRawFd;
+use thiserror::Error;
 
 use async_trait::async_trait;
 #[allow(unused)]
@@ -16,31 +16,18 @@ use crate::task::spawn_blocking;
 
 use crate::file_slice::AsyncFileSlice;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum SendFileError {
-    IoError(IoError),
-    NixError(NixError),
-}
-
-impl fmt::Display for SendFileError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::IoError(err) => write!(f, "{}", err),
-            Self::NixError(err) => write!(f, "{}", err),
-        }
-    }
-}
-
-impl From<IoError> for SendFileError {
-    fn from(error: IoError) -> Self {
-        SendFileError::IoError(error)
-    }
-}
-
-impl From<NixError> for SendFileError {
-    fn from(error: NixError) -> Self {
-        SendFileError::NixError(error)
-    }
+    #[error("IO error: {source}")]
+    IoError {
+        #[from]
+        source: IoError,
+    },
+    #[error("Nix error: {source}")]
+    NixError {
+        #[from]
+        source: NixError,
+    },
 }
 
 /// zero copy write

--- a/src/zero_copy.rs
+++ b/src/zero_copy.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::io::Error as IoError;
 use std::os::unix::io::AsRawFd;
 use thiserror::Error;


### PR DESCRIPTION
This is part of the path to making `fluvio::FluvioError` compatible with `thiserror`, since all encapsulated errors must implement `std::error::Error`, which we currently don't do. I've added `thiserror` to this crate to cover it.