### PR TITLE
make sleep fn unpinnable by removing extra await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-fs",
  "async-io",
@@ -351,6 +351,7 @@ dependencies = [
  "pin-utils",
  "rustls",
  "thiserror",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -1187,6 +1188,18 @@ dependencies = [
  "bytes",
  "futures-core",
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2018"
 authors = ["fluvio.io"]
 description = "I/O futures for Fluvio project"
@@ -54,6 +54,7 @@ num_cpus = "1.10.1"
 futures-util = { version = "0.3.5", features = ["sink"] }
 async-lock = "2.0.0"
 tokio-util = { version = "0.3.1", features = ["codec", "compat"] }
+tokio = { version = "0.2.21", features = ["macros"] }
 flv-util = { version = "0.5.0", features = ["fixture"] }
 fluvio-test-derive = { path = "async-test-derive", version = "0.1.0" }
 fluvio-future = { path = ".", features = ["net", "fixture", "timer", "fs"] }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,15 +2,15 @@ pub use inner::*;
 
 mod inner {
 
-    use std::time::{ Duration, Instant};
+    use std::time::{Duration, Instant};
 
-    use futures_lite::future::Future;
     use async_io::Timer;
+    use futures_lite::future::Future;
 
     /// wait for until `duration` has elapsed.
-    /// 
+    ///
     /// this effectively give back control to async execution engine until duration is finished
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -21,14 +21,13 @@ mod inner {
     ///     sleep(Duration::from_secs(1)).await;
     /// });
     /// ```
-    pub fn sleep(duration: Duration) -> impl Future<Output=Instant> {
+    pub fn sleep(duration: Duration) -> impl Future<Output = Instant> {
         Timer::after(duration)
     }
 }
 
-
 #[cfg(test)]
-mod test{
+mod test {
 
     use std::time::Duration;
     use std::time::Instant;
@@ -39,17 +38,15 @@ mod test{
     use fluvio_future::test_async;
     use fluvio_future::timer::sleep;
 
-    /// test timer loop 
+    /// test timer loop
     #[test_async]
-    async fn test_sleep() -> Result<(),()> {
-
+    async fn test_sleep() -> Result<(), ()> {
         let mut sleep_count: u16 = 0;
         let time_now = Instant::now();
 
         let mut sleep_ft = sleep(Duration::from_millis(10));
 
         for _ in 0u16..10u16 {
-
             select! {
                 _ = &mut sleep_ft => {
                     // fire everytime but won't make cause more delay than initial 10 ms
@@ -61,11 +58,10 @@ mod test{
 
         let elapsed = time_now.elapsed();
 
-        debug!("total time elaspsed: {:#?}",elapsed);
+        debug!("total time elaspsed: {:#?}", elapsed);
         assert!(elapsed < Duration::from_millis(20));
-        assert_eq!(sleep_count,10);
-        
+        assert_eq!(sleep_count, 10);
+
         Ok(())
     }
-
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -59,7 +59,7 @@ mod test {
         let elapsed = time_now.elapsed();
 
         debug!("total time elaspsed: {:#?}", elapsed);
-        assert!(elapsed < Duration::from_millis(20));
+        assert!(elapsed < Duration::from_millis(30));
         assert_eq!(sleep_count, 10);
 
         Ok(())

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,11 +2,70 @@ pub use inner::*;
 
 mod inner {
 
-    use std::time::Duration;
+    use std::time::{ Duration, Instant};
 
+    use futures_lite::future::Future;
     use async_io::Timer;
 
-    pub async fn sleep(duration: Duration) {
-        Timer::after(duration).await;
+    /// wait for until `duration` has elapsed.
+    /// 
+    /// this effectively give back control to async execution engine until duration is finished
+    /// 
+    /// # Examples
+    ///
+    /// ```
+    /// use fluvio_future::timer::sleep;
+    /// use std::time::{Duration, Instant};
+    ///
+    /// fluvio_future::task::run(async {
+    ///     sleep(Duration::from_secs(1)).await;
+    /// });
+    /// ```
+    pub fn sleep(duration: Duration) -> impl Future<Output=Instant> {
+        Timer::after(duration)
     }
+}
+
+
+#[cfg(test)]
+mod test{
+
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use log::debug;
+    use tokio::select;
+
+    use fluvio_future::test_async;
+    use fluvio_future::timer::sleep;
+
+    /// test timer loop 
+    #[test_async]
+    async fn test_sleep() -> Result<(),()> {
+
+        let mut sleep_count: u16 = 0;
+        let time_now = Instant::now();
+
+        let mut sleep_ft = sleep(Duration::from_millis(10));
+
+        for _ in 0u16..10u16 {
+
+            select! {
+                _ = &mut sleep_ft => {
+                    // fire everytime but won't make cause more delay than initial 10 ms
+                    sleep_count += 1;
+                    debug!("timer fired");
+                }
+            }
+        }
+
+        let elapsed = time_now.elapsed();
+
+        debug!("total time elaspsed: {:#?}",elapsed);
+        assert!(elapsed < Duration::from_millis(20));
+        assert_eq!(sleep_count,10);
+        
+        Ok(())
+    }
+
 }


### PR DESCRIPTION
- Remove unnecessary wrapper for sleep by just passing `Timer::after` as future traits.
- Bump up version