### PR TITLE
fix timer compilation error by including futures-lite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         override: true
+    - name: Build
+      run:  make build-all
     - name: Run unit tests
       run:  make test-all
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-fs",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2018"
 authors = ["fluvio.io"]
 description = "I/O futures for Fluvio project"
@@ -17,7 +17,7 @@ net = ["futures-lite", "async-net", "async-trait"]
 tls = ["rust_tls"]
 rust_tls = ["net", "rustls", "webpki", "fluvio-async-tls", "pin-project"]
 native2_tls = ["net","pin-project","async-native-tls","native-tls","openssl"]
-timer = ["async-io","pin-project"]
+timer = ["async-io","pin-project","futures-lite"]
 fs = ["async-fs", "futures-lite", "pin-utils"]
 zero_copy = ["nix", "task_unstable"]
 mmap = ["fs", "memmap", "task_unstable"]


### PR DESCRIPTION
for some reason building timer feature flag works even thought feature dependencies are missing.