### PR TITLE
Simplify TcpDomainConnector by using Trait Object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,16 +22,16 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "once_cell",
- "vec-arena",
+ "slab",
 ]
 
 [[package]]
@@ -63,29 +63,29 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
- "nb-connect",
  "once_cell",
  "parking",
  "polling",
- "vec-arena",
+ "slab",
+ "socket2",
  "waker-fn",
  "winapi",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "async-net"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de475c85affe184648202401d7622afb32f0f74e02192857d0201a16defbe5"
+checksum = "69b0a74e7f70af3c8cf1aa539edbd044795706659ac52b78a71dc1a205ecefdf"
 dependencies = [
  "async-io",
  "blocking",
@@ -125,15 +125,16 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef37b86e2fa961bae5a4d212708ea0154f904ce31d1a4a7f47e1bbc33a0c040b"
+checksum = "a8f38756dd9ac84671c428afbf7c9f7495feff9ec5b0710f17100098e5b354ac"
 dependencies = [
  "async-io",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener",
  "futures-lite",
+ "libc",
  "once_cell",
  "signal-hook",
  "winapi",
@@ -164,7 +165,7 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
- "wasm-bindgen-futures 0.4.21",
+ "wasm-bindgen-futures 0.4.23",
 ]
 
 [[package]]
@@ -175,11 +176,11 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
 ]
@@ -324,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote 1.0.9",
  "syn",
@@ -340,9 +341,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]
@@ -362,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-fs",
  "async-io",
@@ -404,7 +405,7 @@ dependencies = [
 name = "fluvio-test-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
 ]
@@ -452,9 +453,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -467,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -477,15 +478,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -494,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-lite"
@@ -515,27 +516,27 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-timer"
@@ -545,9 +546,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -598,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -624,9 +625,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -648,9 +649,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "lock_api"
@@ -721,16 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
-dependencies = [
- "libc",
- "socket2",
-]
-
-[[package]]
 name = "nix"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,15 +770,15 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -799,9 +790,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "fa52160d45fa2e7608d504b7c3a3355afed615e6d8b627a74458634ba21b69bd"
 dependencies = [
  "autocfg",
  "cc",
@@ -849,20 +840,20 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
 ]
@@ -887,11 +878,11 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-sys",
@@ -927,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -949,7 +940,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
 ]
 
 [[package]]
@@ -994,18 +985,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.4"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fd1046a3107eb58f42de31d656fee6853e5d276c455fd943742dce89fc3dd3"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "regex-syntax",
 ]
@@ -1052,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64",
  "log",
@@ -1093,9 +1084,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -1103,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1116,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1126,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 
 [[package]]
 name = "serde_json"
@@ -1152,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa894ef3fade0ee7243422f4fbbd6c2b48e6de767e621d37ef65f2310f53cea"
+checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1171,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -1183,11 +1174,10 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
  "winapi",
 ]
@@ -1200,11 +1190,11 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.63"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
+checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "unicode-xid 0.2.1",
 ]
@@ -1238,7 +1228,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
 ]
@@ -1254,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1269,9 +1259,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
  "pin-project-lite",
@@ -1284,16 +1274,16 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1318,11 +1308,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41768be5b9f3489491825f56f01f25290aa1d3e7cc97e182d4d34360493ba6fa"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
 ]
@@ -1359,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -1381,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -1438,15 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
-
-[[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "waker-fn"
@@ -1462,9 +1446,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1472,14 +1456,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
  "wasm-bindgen-shared",
@@ -1500,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.21"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1512,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -1522,11 +1506,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn",
  "wasm-bindgen-backend",
@@ -1535,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -1570,20 +1554,20 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.13",
+ "futures 0.3.14",
  "js-sys",
  "parking_lot",
  "pin-utils",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.21",
+ "wasm-bindgen-futures 0.4.23",
  "web-sys",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1601,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +379,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bytes",
+ "dyn-clone",
  "fluvio-async-tls",
  "fluvio-future",
  "fluvio-test-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,12 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
-
-[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,7 +373,6 @@ dependencies = [
  "async-std",
  "async-trait",
  "bytes",
- "dyn-clone",
  "fluvio-async-tls",
  "fluvio-future",
  "fluvio-test-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ subscriber = ["tracing-subscriber"]
 fixture = ["subscriber", "task", "fluvio-test-derive"]
 task_unstable = ["task", "async-std/unstable"]
 io = ["async-std/default"]
-net = ["futures-lite", "async-net", "async-trait"]
+net = ["futures-lite", "async-net", "async-trait","dyn-clone"]
 tls = ["rust_tls"]
 rust_tls = ["net", "rustls", "webpki", "fluvio-async-tls", "pin-project"]
 native2_tls = ["net", "pin-project", "async-native-tls", "native-tls", "openssl"]
@@ -36,6 +36,8 @@ nix = { version = "0.20.0", optional = true }
 bytes = { version = "1.0.0", optional = true }
 async-trait = { version = "0.1.40", optional = true }
 webpki = { version = "0.21", optional = true }
+dyn-clone = { version = "1.0.4", optional = true}
+
 fluvio-async-tls = { version = "0.2.0", optional = true }
 thiserror = "1.0.20"
 fluvio-test-derive = { path = "async-test-derive", version = "0.1.0", optional = true }
@@ -43,7 +45,7 @@ fluvio-test-derive = { path = "async-test-derive", version = "0.1.0", optional =
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-std = { version = "1.6.2", default-features = false, optional = true }
 async-io = { version = "1.1.2", optional = true }
-async-net = { version = "1.3.0", optional = true }
+async-net = { version = "1.6.0", optional = true }
 memmap = { version = "0.7.0", optional = true }
 openssl = { version = "0.10.30", optional = true }
 openssl-sys = { version = "0.9.58", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["fluvio.io"]
 description = "I/O futures for Fluvio project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ task_unstable = ["task", "async-std/unstable"]
 io = ["async-std/default"]
 net = ["futures-lite", "async-net", "async-trait"]
 tls = ["rust_tls"]
-rust_tls = ["net", "rustls", "webpki", "fluvio-async-tls", "pin-project"]
-native2_tls = ["net", "pin-project", "async-native-tls", "native-tls", "openssl"]
-openssl_tls = ["net", "openssl", "openssl-sys", "pin-project"]
+rust_tls = ["net", "rustls", "webpki", "fluvio-async-tls", "pin-project","futures-util"]
+native2_tls = ["net", "pin-project", "async-native-tls", "native-tls", "openssl","futures-util"]
+openssl_tls = ["net", "openssl", "openssl-sys", "pin-project","futures-util"]
 timer = ["async-io", "pin-project", "futures-lite"]
 fs = ["async-fs", "futures-lite", "pin-utils"]
 zero_copy = ["nix", "task_unstable"]
@@ -26,6 +26,7 @@ mmap = ["fs", "memmap", "task_unstable"]
 [dependencies]
 log = "0.4.0"
 futures-lite = { version = "1.11.2", optional = true }
+futures-util = { version = "0.3.5", optional = true, features = ["sink", "io"] }
 futures-timer = { version = "3.0.0", optional = true }
 async-fs = { version = "1.3.0", optional = true }
 pin-utils = { version = "0.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ subscriber = ["tracing-subscriber"]
 fixture = ["subscriber", "task", "fluvio-test-derive"]
 task_unstable = ["task", "async-std/unstable"]
 io = ["async-std/default"]
-net = ["futures-lite", "async-net", "async-trait","dyn-clone"]
+net = ["futures-lite", "async-net", "async-trait"]
 tls = ["rust_tls"]
 rust_tls = ["net", "rustls", "webpki", "fluvio-async-tls", "pin-project"]
 native2_tls = ["net", "pin-project", "async-native-tls", "native-tls", "openssl"]
@@ -36,7 +36,7 @@ nix = { version = "0.20.0", optional = true }
 bytes = { version = "1.0.0", optional = true }
 async-trait = { version = "0.1.40", optional = true }
 webpki = { version = "0.21", optional = true }
-dyn-clone = { version = "1.0.4", optional = true}
+
 
 fluvio-async-tls = { version = "0.2.0", optional = true }
 thiserror = "1.0.20"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use fluvio_test_derive::test_async;
 pub mod zero_copy;
 
 #[cfg(feature = "net")]
+#[cfg(unix)]
 #[cfg(not(target_arch = "wasm32"))]
 pub mod net;
 

--- a/src/native_tls.rs
+++ b/src/native_tls.rs
@@ -411,10 +411,10 @@ mod test {
     use tokio_util::codec::Framed;
     use tokio_util::compat::FuturesAsyncReadCompatExt;
 
-    use fluvio_future::net::TcpListener;
-    use fluvio_future::net::TcpStream;
-    use fluvio_future::test_async;
-    use fluvio_future::timer::sleep;
+    use crate::net::TcpListener;
+    use crate::net::TcpStream;
+    use crate::test_async;
+    use crate::timer::sleep;
 
     use super::{
         AcceptorBuilder, AllTcpStream, CertBuilder, ConnectorBuilder, IdentityBuilder,

--- a/src/native_tls.rs
+++ b/src/native_tls.rs
@@ -24,7 +24,7 @@ mod connector {
     use async_trait::async_trait;
     use log::debug;
 
-    use crate::net::{Connection, TcpDomainConnector};
+    use crate::net::{Connection, DomainConnector, TcpDomainConnector};
 
     use super::*;
 
@@ -69,8 +69,12 @@ mod connector {
             Ok((Box::new(connector), fd))
         }
 
-        fn new_domain(&self, _domain: String) -> Self {
-            self.clone()
+        fn new_domain(&self, _domain: String) -> DomainConnector {
+            Box::new(self.clone())
+        }
+
+        fn domain(&self) -> &str {
+            "localhost"
         }
     }
 
@@ -119,10 +123,14 @@ mod connector {
             Ok((Box::new(connector), fd))
         }
 
-        fn new_domain(&self, domain: String) -> Self {
+        fn new_domain(&self, domain: String) -> DomainConnector {
             let mut connector = self.clone();
             connector.domain = domain;
-            connector
+            Box::new(connector)
+        }
+
+        fn domain(&self) -> &str {
+            &self.domain
         }
     }
 }

--- a/src/native_tls.rs
+++ b/src/native_tls.rs
@@ -24,7 +24,6 @@ mod connector {
     use async_trait::async_trait;
     use log::debug;
 
-    use crate::net::DefaultTcpDomainConnector;
     use crate::net::{Connection, TcpDomainConnector};
 
     use super::*;

--- a/src/native_tls.rs
+++ b/src/native_tls.rs
@@ -68,6 +68,10 @@ mod connector {
             })?;
             Ok((Box::new(connector), fd))
         }
+
+        fn new_domain(&self, _domain: String) -> Self {
+            self.clone()
+        }
     }
 
     /// Connect to TLS
@@ -88,8 +92,6 @@ mod connector {
         pub fn domain(&self) -> &str {
             &self.domain
         }
-
-        
 
         pub fn connector(&self) -> &TlsConnector {
             &self.connector
@@ -117,8 +119,10 @@ mod connector {
             Ok((Box::new(connector), fd))
         }
 
-        fn set_domain(&mut self, domain: String) {
-            self.domain = domain;
+        fn new_domain(&self, domain: String) -> Self {
+            let mut connector = self.clone();
+            connector.domain = domain;
+            connector
         }
     }
 }

--- a/src/native_tls.rs
+++ b/src/native_tls.rs
@@ -11,6 +11,22 @@ pub type DefaultClientTlsStream = TlsStream<TcpStream>;
 pub use connector::*;
 pub use stream::*;
 
+mod split {
+
+    use async_net::TcpStream;
+    use futures_util::AsyncReadExt;
+
+    use super::*;
+    use crate::net::{BoxReadConnection, BoxWriteConnection, SplitConnection};
+
+    impl SplitConnection for TlsStream<TcpStream> {
+        fn split_connection(self) -> (BoxWriteConnection, BoxReadConnection) {
+            let (read, write) = self.split();
+            (Box::new(write), Box::new(read))
+        }
+    }
+}
+
 mod connector {
 
     use std::io::Error as IoError;

--- a/src/native_tls.rs
+++ b/src/native_tls.rs
@@ -89,9 +89,7 @@ mod connector {
             &self.domain
         }
 
-        pub fn set_domain(&mut self, domain: String) {
-            self.domain = domain;
-        }
+        
 
         pub fn connector(&self) -> &TlsConnector {
             &self.connector
@@ -117,6 +115,10 @@ mod connector {
                     )
                 })?;
             Ok((Box::new(connector), fd))
+        }
+
+        fn set_domain(&mut self, domain: String) {
+            self.domain = domain;
         }
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -11,12 +11,14 @@ pub use conn::*;
 mod conn {
 
     use futures_lite::io::{AsyncRead, AsyncWrite};
+    use dyn_clone::DynClone;
 
-    pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin {}
-    impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin> Connection for T {}
+    pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + DynClone {}
+    impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + DynClone > Connection for T {}
 
     pub type BoxConnection = Box<dyn Connection>;
 
+    /* 
     pub trait ConnectionClone {
         fn clone_box(&self) -> BoxConnection;
     }
@@ -35,6 +37,7 @@ mod conn {
             self.clone_box()
         }
     }
+    */
 
    
 }
@@ -137,7 +140,7 @@ mod test {
             sleep(time::Duration::from_millis(100)).await;
             let tcp_stream = TcpStream::connect(&addr).await.expect("test");
             let read: BoxConnection = Box::new(tcp_stream);
-            let write = read.clone_box();
+            let write =  dyn_clone::clone_box(&*read);
             assert!(true);
         };
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -57,7 +57,9 @@ mod connector {
         async fn connect(&self, domain: &str) -> Result<(BoxConnection, RawFd), IoError>;
 
         // create new version of my self with new domain
-        fn new_domain(&self, domain: String) -> Self;
+        fn new_domain(&self, domain: String) -> Self
+        where
+            Self: Sized;
     }
 
     /*
@@ -76,7 +78,7 @@ mod connector {
     */
 
     /// creatges TcpStream connection
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     pub struct DefaultTcpDomainConnector {}
 
     impl DefaultTcpDomainConnector {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -57,9 +57,9 @@ mod connector {
         async fn connect(&self, domain: &str) -> Result<(BoxConnection, RawFd), IoError>;
 
         // create new version of my self with new domain
-        fn new_domain(&self, domain: String) -> Self
-        where
-            Self: Sized;
+        fn new_domain(&self, domain: String) -> DomainConnector;
+
+        fn domain(&self) -> &str;
     }
 
     /*
@@ -96,8 +96,12 @@ mod connector {
             Ok((Box::new(tcp_stream), fd))
         }
 
-        fn new_domain(&self, _domain: String) -> Self {
-            self.clone()
+        fn new_domain(&self, _domain: String) -> DomainConnector {
+            Box::new(self.clone())
+        }
+
+        fn domain(&self) -> &str {
+            "localhost"
         }
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -40,7 +40,7 @@ mod conn {
 
 #[cfg(unix)]
 mod connector {
-    use std::io::Error as IoError;
+    use std::{io::Error as IoError};
     use std::os::unix::io::AsRawFd;
     use std::os::unix::io::RawFd;
 
@@ -55,8 +55,14 @@ mod connector {
     #[async_trait]
     pub trait TcpDomainConnector: Send + Sync {
         async fn connect(&self, domain: &str) -> Result<(BoxConnection, RawFd), IoError>;
+
+        fn set_domain(&mut self, _domain: String) {
+
+        }
+
     }
 
+    /* 
     trait DomainConnectorClone {
         fn clone_box(&self) -> DomainConnector;
     }
@@ -69,6 +75,7 @@ mod connector {
             Box::new(self.clone())
         }
     }
+    */
 
     /// creatges TcpStream connection
     #[derive(Clone)]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -40,7 +40,7 @@ mod conn {
 
 #[cfg(unix)]
 mod connector {
-    use std::{io::Error as IoError};
+    use std::io::Error as IoError;
     use std::os::unix::io::AsRawFd;
     use std::os::unix::io::RawFd;
 
@@ -56,13 +56,11 @@ mod connector {
     pub trait TcpDomainConnector: Send + Sync {
         async fn connect(&self, domain: &str) -> Result<(BoxConnection, RawFd), IoError>;
 
-        fn set_domain(&mut self, _domain: String) {
-
-        }
-
+        // create new version of my self with new domain
+        fn new_domain(&self, domain: String) -> Self;
     }
 
-    /* 
+    /*
     trait DomainConnectorClone {
         fn clone_box(&self) -> DomainConnector;
     }
@@ -94,6 +92,10 @@ mod connector {
             let tcp_stream = TcpStream::connect(addr).await?;
             let fd = tcp_stream.as_raw_fd();
             Ok((Box::new(tcp_stream), fd))
+        }
+
+        fn new_domain(&self, _domain: String) -> Self {
+            self.clone()
         }
     }
 }

--- a/src/openssl/connector.rs
+++ b/src/openssl/connector.rs
@@ -9,7 +9,7 @@ use futures_lite::io::{AsyncRead, AsyncWrite};
 use log::debug;
 use openssl::ssl;
 
-use crate::net::{BoxConnection, TcpDomainConnector, TcpStream};
+use crate::net::{BoxConnection, DomainConnector, TcpDomainConnector, TcpStream};
 
 use super::async_to_sync_wrapper::AsyncToSyncWrapper;
 use super::certificate::Certificate;
@@ -123,8 +123,12 @@ impl TcpDomainConnector for TlsAnonymousConnector {
         ))
     }
 
-    fn new_domain(&self, _domain: String) -> Self {
-        self.clone()
+    fn new_domain(&self, _domain: String) -> DomainConnector {
+        Box::new(self.clone())
+    }
+
+    fn domain(&self) -> &str {
+        "localhost"
     }
 }
 
@@ -159,9 +163,13 @@ impl TcpDomainConnector for TlsDomainConnector {
         ))
     }
 
-    fn new_domain(&self, domain: String) -> Self {
+    fn new_domain(&self, domain: String) -> DomainConnector {
         let mut connector = self.clone();
         connector.domain = domain;
-        connector
+        Box::new(connector)
+    }
+
+    fn domain(&self) -> &str {
+        "localhost"
     }
 }

--- a/src/openssl/connector.rs
+++ b/src/openssl/connector.rs
@@ -122,6 +122,10 @@ impl TcpDomainConnector for TlsAnonymousConnector {
             fd,
         ))
     }
+
+    fn new_domain(&self, _domain: String) -> Self {
+        self.clone()
+    }
 }
 
 #[derive(Clone)]
@@ -153,5 +157,11 @@ impl TcpDomainConnector for TlsDomainConnector {
             ),
             fd,
         ))
+    }
+
+    fn new_domain(&self, domain: String) -> Self {
+        let mut connector = self.clone();
+        connector.domain = domain;
+        connector
     }
 }

--- a/src/openssl/mod.rs
+++ b/src/openssl/mod.rs
@@ -10,10 +10,7 @@ mod test;
 
 pub use acceptor::{TlsAcceptor, TlsAcceptorBuilder};
 pub use certificate::Certificate;
-pub use connector::{
-    AllDomainConnector, TlsAnonymousConnector, TlsConnector, TlsConnectorBuilder,
-    TlsDomainConnector,
-};
+pub use connector::{TlsAnonymousConnector, TlsConnector, TlsConnectorBuilder, TlsDomainConnector};
 pub use error::Error as TlsError;
 pub use openssl::ssl::SslVerifyMode;
 pub use stream::{AllTcpStream, TlsStream};

--- a/src/openssl/mod.rs
+++ b/src/openssl/mod.rs
@@ -17,3 +17,19 @@ pub use stream::{AllTcpStream, TlsStream};
 
 pub type DefaultServerTlsStream = TlsStream<crate::net::TcpStream>;
 pub type DefaultClientTlsStream = TlsStream<crate::net::TcpStream>;
+
+mod split {
+
+    use async_net::TcpStream;
+    use futures_util::AsyncReadExt;
+
+    use super::*;
+    use crate::net::{BoxReadConnection, BoxWriteConnection, SplitConnection};
+
+    impl SplitConnection for TlsStream<TcpStream> {
+        fn split_connection(self) -> (BoxWriteConnection, BoxReadConnection) {
+            let (read, write) = self.split();
+            (Box::new(write), Box::new(read))
+        }
+    }
+}

--- a/src/rust_tls.rs
+++ b/src/rust_tls.rs
@@ -97,8 +97,7 @@ mod connector {
         }
 
         fn new_domain(&self, _domain: String) -> Self {
-            let connector = self.clone();
-            connector
+            self.clone()
         }
     }
 

--- a/src/rust_tls.rs
+++ b/src/rust_tls.rs
@@ -95,6 +95,11 @@ mod connector {
             let fd = tcp_stream.as_raw_fd();
             Ok((Box::new(self.0.connect(domain, tcp_stream).await?), fd))
         }
+
+        fn new_domain(&self, _domain: String) -> Self {
+            let connector = self.clone();
+            connector
+        }
     }
 
     #[derive(Clone)]
@@ -121,6 +126,12 @@ mod connector {
                 Box::new(self.connector.connect(&self.domain, tcp_stream).await?),
                 fd,
             ))
+        }
+
+        fn new_domain(&self, domain: String) -> Self {
+            let mut connector = self.clone();
+            connector.domain = domain;
+            connector
         }
     }
 }

--- a/src/rust_tls.rs
+++ b/src/rust_tls.rs
@@ -69,13 +69,10 @@ mod connector {
     use std::os::unix::io::RawFd;
 
     use async_trait::async_trait;
-
-    use crate::net::DefaultTcpDomainConnector;
-    use crate::net::TcpDomainConnector;
     use log::debug;
 
-    use super::AllTcpStream;
-    use super::DefaultClientTlsStream;
+    use crate::net::{BoxConnection, TcpDomainConnector};
+
     use super::TcpStream;
     use super::TlsConnector;
 
@@ -93,9 +90,7 @@ mod connector {
 
     #[async_trait]
     impl TcpDomainConnector for TlsAnonymousConnector {
-        type WrapperStream = DefaultClientTlsStream;
-
-        async fn connect(&self, domain: &str) -> Result<(Self::WrapperStream, RawFd), IoError> {
+        async fn connect(&self, domain: &str) -> Result<(Box<dyn Connection>, RawFd), IoError> {
             let tcp_stream = TcpStream::connect(domain).await?;
             let fd = tcp_stream.as_raw_fd();
             Ok((self.0.connect(domain, tcp_stream).await?, fd))
@@ -116,65 +111,16 @@ mod connector {
 
     #[async_trait]
     impl TcpDomainConnector for TlsDomainConnector {
-        type WrapperStream = DefaultClientTlsStream;
-
-        async fn connect(&self, addr: &str) -> Result<(Self::WrapperStream, RawFd), IoError> {
+        async fn connect(&self, addr: &str) -> Result<(BoxConnection, RawFd), IoError> {
             debug!("connect to tls addr: {}", addr);
             let tcp_stream = TcpStream::connect(addr).await?;
             let fd = tcp_stream.as_raw_fd();
 
             debug!("connect to tls domain: {}", self.domain);
-            Ok((self.connector.connect(&self.domain, tcp_stream).await?, fd))
-        }
-    }
-
-    #[derive(Clone)]
-    pub enum AllDomainConnector {
-        Tcp(DefaultTcpDomainConnector),
-        TlsDomain(TlsDomainConnector),
-        TlsAnonymous(TlsAnonymousConnector),
-    }
-
-    impl Default for AllDomainConnector {
-        fn default() -> Self {
-            Self::default_tcp()
-        }
-    }
-
-    impl AllDomainConnector {
-        pub fn default_tcp() -> Self {
-            Self::Tcp(DefaultTcpDomainConnector)
-        }
-
-        pub fn new_tls_domain(connector: TlsDomainConnector) -> Self {
-            Self::TlsDomain(connector)
-        }
-
-        pub fn new_tls_anonymous(connector: TlsAnonymousConnector) -> Self {
-            Self::TlsAnonymous(connector)
-        }
-    }
-
-    #[async_trait]
-    impl TcpDomainConnector for AllDomainConnector {
-        type WrapperStream = AllTcpStream;
-
-        async fn connect(&self, domain: &str) -> Result<(Self::WrapperStream, RawFd), IoError> {
-            match self {
-                Self::Tcp(connector) => {
-                    let (stream, fd) = connector.connect(domain).await?;
-                    Ok((AllTcpStream::tcp(stream), fd))
-                }
-
-                Self::TlsDomain(connector) => {
-                    let (stream, fd) = connector.connect(domain).await?;
-                    Ok((AllTcpStream::tls(stream), fd))
-                }
-                Self::TlsAnonymous(connector) => {
-                    let (stream, fd) = connector.connect(domain).await?;
-                    Ok((AllTcpStream::tls(stream), fd))
-                }
-            }
+            Ok((
+                Box::new(self.connector.connect(&self.domain, tcp_stream).await?),
+                fd,
+            ))
         }
     }
 }

--- a/src/rust_tls.rs
+++ b/src/rust_tls.rs
@@ -71,7 +71,7 @@ mod connector {
     use async_trait::async_trait;
     use log::debug;
 
-    use crate::net::{BoxConnection, TcpDomainConnector};
+    use crate::net::{BoxConnection, DomainConnector, TcpDomainConnector};
 
     use super::TcpStream;
     use super::TlsConnector;
@@ -96,8 +96,12 @@ mod connector {
             Ok((Box::new(self.0.connect(domain, tcp_stream).await?), fd))
         }
 
-        fn new_domain(&self, _domain: String) -> Self {
-            self.clone()
+        fn new_domain(&self, _domain: String) -> DomainConnector {
+            Box::new(self.clone())
+        }
+
+        fn domain(&self) -> &str {
+            "localhost"
         }
     }
 
@@ -127,10 +131,14 @@ mod connector {
             ))
         }
 
-        fn new_domain(&self, domain: String) -> Self {
+        fn new_domain(&self, domain: String) -> DomainConnector {
             let mut connector = self.clone();
             connector.domain = domain;
-            connector
+            Box::new(connector)
+        }
+
+        fn domain(&self) -> &str {
+            &self.domain
         }
     }
 }

--- a/src/rust_tls.rs
+++ b/src/rust_tls.rs
@@ -90,10 +90,10 @@ mod connector {
 
     #[async_trait]
     impl TcpDomainConnector for TlsAnonymousConnector {
-        async fn connect(&self, domain: &str) -> Result<(Box<dyn Connection>, RawFd), IoError> {
+        async fn connect(&self, domain: &str) -> Result<(BoxConnection, RawFd), IoError> {
             let tcp_stream = TcpStream::connect(domain).await?;
             let fd = tcp_stream.as_raw_fd();
-            Ok((self.0.connect(domain, tcp_stream).await?, fd))
+            Ok((Box::new(self.0.connect(domain, tcp_stream).await?), fd))
         }
     }
 

--- a/src/zero_copy.rs
+++ b/src/zero_copy.rs
@@ -1,5 +1,5 @@
 use std::io::Error as IoError;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use thiserror::Error;
 
 use async_trait::async_trait;
@@ -30,19 +30,21 @@ pub enum SendFileError {
 }
 
 /// zero copy write
-#[async_trait]
-pub trait ZeroCopyWrite {
-    async fn zero_copy_write(&mut self, source: &AsyncFileSlice) -> Result<usize, SendFileError>;
+pub struct ZeroCopy(RawFd);
+
+impl ZeroCopy {
+    pub fn from<S>(fd: &mut S) -> Self
+    where
+        S: AsRawFd,
+    {
+        Self(fd.as_raw_fd())
+    }
 }
 
-#[async_trait]
-impl<T> ZeroCopyWrite for T
-where
-    T: AsRawFd + Send,
-{
-    async fn zero_copy_write(&mut self, source: &AsyncFileSlice) -> Result<usize, SendFileError> {
+impl ZeroCopy {
+    pub async fn copy_from(&self, source: &AsyncFileSlice) -> Result<usize, SendFileError> {
         let size = source.len();
-        let target_fd = self.as_raw_fd();
+        let target_fd = self.0;
         let source_fd = source.fd();
 
         #[cfg(target_os = "linux")]
@@ -170,13 +172,12 @@ mod tests {
     use futures_util::stream::StreamExt;
     use log::debug;
 
-    use crate::fs::util as file_util;
     use crate::fs::AsyncFileExtension;
     use crate::net::TcpListener;
     use crate::net::TcpStream;
     use crate::test_async;
     use crate::timer::sleep;
-    use crate::zero_copy::ZeroCopyWrite;
+    use crate::{fs::util as file_util, zero_copy::ZeroCopy};
     use futures_lite::AsyncReadExt;
 
     use super::SendFileError;
@@ -214,7 +215,8 @@ mod tests {
             debug!("client: connected to server");
             let f_slice = file.as_slice(0, None).await?;
             debug!("client: send back file using zero copy");
-            stream.zero_copy_write(&f_slice).await?;
+            let writer = ZeroCopy::from(&mut stream);
+            writer.copy_from(&f_slice).await?;
             Ok(()) as Result<(), SendFileError>
         };
 
@@ -277,10 +279,9 @@ mod tests {
                     i,
                     f_slice.len()
                 );
-                tcp_stream
-                    .zero_copy_write(&f_slice)
-                    .await
-                    .expect("file slice");
+
+                let writer = ZeroCopy::from(&mut tcp_stream);
+                writer.copy_from(&f_slice).await.expect("file slice");
             }
 
             Ok(()) as Result<(), SendFileError>


### PR DESCRIPTION
Create `Connection` Box Trait that represent any network connection

```
pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection {}
    impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection> Connection for T {}

    pub trait ReadConnection: AsyncRead + Send + Sync + Unpin {}
    impl<T: AsyncRead + Send + Sync + Unpin> ReadConnection for T {}

    pub trait WriteConnection: AsyncWrite + Send + Sync + Unpin {}
    impl<T: AsyncWrite + Send + Sync + Unpin> WriteConnection for T {}

    pub type BoxConnection = Box<dyn Connection>;
    pub type BoxReadConnection = Box<dyn ReadConnection>;
    pub type BoxWriteConnection = Box<dyn WriteConnection>;

```

And Connector that can create boxed Connection
```
#[async_trait]
    pub trait TcpDomainConnector: Send + Sync {
        async fn connect(
            &self,
            domain: &str,
        ) -> Result<(BoxWriteConnection, BoxReadConnection, RawFd), IoError>;

        // create new version of my self with new domain
        fn new_domain(&self, domain: String) -> DomainConnector;

        fn domain(&self) -> &str;
    }
```

With this change, it's easy to create any types of network connection including WASM


