### PR TITLE
Websocket connector

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,2 @@
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"
-
-[target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,23 @@ jobs:
 
     - name: Run wasm tests
       run:  make test-wasm
+
+  wasm_test_macos:
+    name: Wasm Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        rust: [stable]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install ${{ matrix.rust }}
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        override: true
+        target: wasm32-unknown-unknown
+
+    - name: Run wasm tests
+      run:  make test-wasm-safari

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "tracing-wasm",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "webpki",
@@ -592,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -957,9 +958,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -1457,6 +1458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-wasm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae741706df70547fca8715f74a8569677666e7be3454313af70f6e158034485"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,7 +1703,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "ws_stream_wasm"
 version = "0.7.0"
-source = "git+https://github.com/simlay/ws_stream_wasm?branch=add-clone-to-wsstream#3abc6e53e17747f2b29821f7cb467acaf0247b70"
+source = "git+https://github.com/simlay/ws_stream_wasm?branch=add-clone-to-wsstream-again#74e6512b5040ab96e1c5739ad7d420e8f9d39c52"
 dependencies = [
  "async_io_stream",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-fs",
  "async-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
- "wasm-bindgen-futures 0.4.24",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -180,8 +180,8 @@ version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -191,7 +191,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d5ad740b7193a31e80950ab7fece57c38d426fcd23a729d9d7f4cf15bb63f94"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "pharos",
  "rustc_version 0.3.3",
 ]
@@ -340,7 +340,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
- "quote 1.0.9",
+ "quote",
  "syn",
 ]
 
@@ -390,6 +390,7 @@ dependencies = [
  "fluvio-test-derive",
  "fluvio-wasm-timer",
  "flv-util",
+ "futures",
  "futures-lite",
  "futures-timer",
  "futures-util",
@@ -409,6 +410,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "webpki",
  "ws_stream_wasm",
@@ -418,8 +420,8 @@ dependencies = [
 name = "fluvio-test-derive"
 version = "0.1.1"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -429,12 +431,12 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "js-sys",
  "parking_lot",
  "pin-utils",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.24",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -472,12 +474,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -550,8 +546,8 @@ checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -886,7 +882,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e5f09cc3d3cb227536487dfe7fb8c246eccc6c8a32d03daa30ba4cf3212917"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "rustc_version 0.2.3",
 ]
 
@@ -905,8 +901,8 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -961,29 +957,11 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
- "unicode-xid 0.2.2",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -992,7 +970,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1303,9 +1281,9 @@ version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "unicode-xid 0.2.2",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1337,8 +1315,8 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1383,8 +1361,8 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1421,8 +1399,8 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1504,12 +1482,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
@@ -1585,23 +1557,10 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
-dependencies = [
- "cfg-if 0.1.10",
- "futures 0.1.31",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1622,7 +1581,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
- "quote 1.0.9",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1632,8 +1591,8 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -1647,27 +1606,26 @@ checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.2.50"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d9693b63a742d481c7f80587e057920e568317b2806988c59cd71618bc26c1"
+checksum = "8cab416a9b970464c2882ed92d55b0c33046b08e0bdc9d59b3b718acd4e1bae8"
 dependencies = [
  "console_error_panic_hook",
- "futures 0.1.31",
  "js-sys",
  "scoped-tls",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.3.27",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.2.50"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0789dac148a8840bbcf9efe13905463b733fa96543bfbf263790535c11af7ba5"
+checksum = "dd4543fc6cf3541ef0d98bf720104cc6bd856d7eba449fd2aa365ef4fed0e782"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1733,17 +1691,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "ws_stream_wasm"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9528a8ec27f348ae922b166e86670ef8be9f0427642d1f8725289f07e5207cd7"
+source = "git+https://github.com/simlay/ws_stream_wasm?branch=add-clone-to-wsstream#3abc6e53e17747f2b29821f7cb467acaf0247b70"
 dependencies = [
  "async_io_stream",
- "futures 0.3.15",
+ "futures",
  "js-sys",
  "pharos",
  "rustc_version 0.3.3",
  "send_wrapper",
  "thiserror",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.24",
+ "wasm-bindgen-futures",
  "web-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,6 @@ dependencies = [
  "fluvio-test-derive",
  "fluvio-wasm-timer",
  "flv-util",
- "futures",
  "futures-lite",
  "futures-timer",
  "futures-util",
@@ -1703,7 +1702,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "ws_stream_wasm"
 version = "0.7.0"
-source = "git+https://github.com/simlay/ws_stream_wasm?branch=add-clone-to-wsstream-again#74e6512b5040ab96e1c5739ad7d420e8f9d39c52"
+source = "git+https://github.com/infinyon/ws_stream_wasm?branch=add-clone-to-wsstream-again#74e6512b5040ab96e1c5739ad7d420e8f9d39c52"
 dependencies = [
  "async_io_stream",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d5ad740b7193a31e80950ab7fece57c38d426fcd23a729d9d7f4cf15bb63f94"
+dependencies = [
+ "futures 0.3.15",
+ "pharos",
+ "rustc_version 0.3.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +411,7 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen-test",
  "webpki",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -860,6 +872,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e5f09cc3d3cb227536487dfe7fb8c246eccc6c8a32d03daa30ba4cf3212917"
+dependencies = [
+ "futures 0.3.15",
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1094,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1184,45 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "send_wrapper"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
@@ -1391,6 +1479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,3 +1729,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9528a8ec27f348ae922b166e86670ef8be9f0427642d1f8725289f07e5207cd7"
+dependencies = [
+ "async_io_stream",
+ "futures 0.3.15",
+ "js-sys",
+ "pharos",
+ "rustc_version 0.3.3",
+ "send_wrapper",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures 0.4.24",
+ "web-sys",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 resolver = "2"
 
 [features]
-default = ["net"]
 task = ["async-std/default", "timer","cfg-if"]
 subscriber = ["tracing-subscriber"]
 fixture = ["subscriber", "task", "fluvio-test-derive"]
@@ -73,8 +72,7 @@ rustls = { version = "0.19.0", features = ["dangerous_configuration"], optional 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fluvio-wasm-timer = "0.2.5"
 async-std = { version = "1.6.2", default-features = false, features = ["unstable"], optional = true }
-ws_stream_wasm = { git = "https://github.com/simlay/ws_stream_wasm", branch = "add-clone-to-wsstream-again" }
-futures = { version = "0.3.15", features = ["bilock", "unstable"] }
+ws_stream_wasm = { git = "https://github.com/infinyon/ws_stream_wasm", branch = "add-clone-to-wsstream-again" }
 
 [dev-dependencies]
 bytes = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 resolver = "2"
 
 [features]
+default = ["net"]
 task = ["async-std/default", "timer","cfg-if"]
 subscriber = ["tracing-subscriber"]
 fixture = ["subscriber", "task", "fluvio-test-derive"]
@@ -72,7 +73,8 @@ rustls = { version = "0.19.0", features = ["dangerous_configuration"], optional 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fluvio-wasm-timer = "0.2.5"
 async-std = { version = "1.6.2", default-features = false, features = ["unstable"], optional = true }
-ws_stream_wasm = "0.7.0"
+ws_stream_wasm = { git = "https://github.com/simlay/ws_stream_wasm", branch = "add-clone-to-wsstream" }
+futures = { version = "0.3.15", features = ["bilock", "unstable"] }
 
 [dev-dependencies]
 bytes = "1.0.0"
@@ -87,4 +89,5 @@ fluvio-test-derive = { path = "async-test-derive", version = "0.1.0" }
 fluvio-future = { path = ".", features = ["net", "fixture", "timer", "fs"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.2"
+wasm-bindgen-test = "0.3.24"
+wasm-bindgen-futures = "0.4.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ rustls = { version = "0.19.0", features = ["dangerous_configuration"], optional 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fluvio-wasm-timer = "0.2.5"
 async-std = { version = "1.6.2", default-features = false, features = ["unstable"], optional = true }
-ws_stream_wasm = { git = "https://github.com/simlay/ws_stream_wasm", branch = "add-clone-to-wsstream" }
+ws_stream_wasm = { git = "https://github.com/simlay/ws_stream_wasm", branch = "add-clone-to-wsstream-again" }
 futures = { version = "0.3.15", features = ["bilock", "unstable"] }
 
 [dev-dependencies]
@@ -91,3 +91,4 @@ fluvio-future = { path = ".", features = ["net", "fixture", "timer", "fs"] }
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.24"
 wasm-bindgen-futures = "0.4.24"
+tracing-wasm = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ rustls = { version = "0.19.0", features = ["dangerous_configuration"], optional 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fluvio-wasm-timer = "0.2.5"
 async-std = { version = "1.6.2", default-features = false, features = ["unstable"], optional = true }
+ws_stream_wasm = "0.7.0"
 
 [dev-dependencies]
 bytes = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,15 @@ build-all:
 test-all:	test-derive
 	cargo test --all-features
 
-install-wasm-cli:
-	cargo install wasm-bindgen-cli
+install-wasm-pack:
+	which wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-test-wasm: install-wasm32 install-wasm-cli
-	cargo test --all-features --target wasm32-unknown-unknown
+test-wasm: install-wasm32 install-wasm-pack
+	wasm-pack test --firefox --headless
+	wasm-pack test --chrome --headless
+
+test-wasm-safari: install-wasm32 install-wasm-pack
+	wasm-pack test --safari --headless
 
 test-derive:
 	cd async-test-derive; cargo test

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -11,10 +11,7 @@ pub use conn::*;
 pub use unix_connector::DefaultTcpDomainConnector as DefaultDomainConnector;
 
 #[cfg(unix)]
-#[deprecated(
-    since = "0.3.3",
-    note = "Please use the bar DefaultDomainConnector"
-)]
+#[deprecated(since = "0.3.3", note = "Please use the bar DefaultDomainConnector")]
 pub use unix_connector::DefaultTcpDomainConnector;
 
 #[cfg(target_arch = "wasm32")]
@@ -104,7 +101,9 @@ mod wasm_connector {
             &self,
             addr: &str,
         ) -> Result<(BoxWriteConnection, BoxReadConnection, ConnectionFd), IoError> {
-            let (mut _ws, wsstream) = WsMeta::connect(addr, None).await.map_err(|e| IoError::new(std::io::ErrorKind::Other, e))?;
+            let (mut _ws, wsstream) = WsMeta::connect(addr, None)
+                .await
+                .map_err(|e| IoError::new(std::io::ErrorKind::Other, e))?;
             let wsstream_clone = wsstream.clone();
             Ok((
                 Box::new(wsstream.into_io()),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -41,10 +41,9 @@ mod conn {
             impl<T: AsyncWrite + Unpin> WriteConnection for T {}
         }
     }
-    pub type BoxConnection      = Box<dyn Connection>;
-    pub type BoxReadConnection  = Box<dyn ReadConnection>;
+    pub type BoxConnection = Box<dyn Connection>;
+    pub type BoxReadConnection = Box<dyn ReadConnection>;
     pub type BoxWriteConnection = Box<dyn WriteConnection>;
-
 
     pub trait SplitConnection {
         // split into write and read
@@ -79,16 +78,14 @@ mod conn {
     }
 }
 
-
 #[cfg(target_arch = "wasm32")]
 mod wasm_connector {
     use super::*;
-    use std::io::Error as IoError;
     use async_trait::async_trait;
+    use std::io::Error as IoError;
     use ws_stream_wasm::WsMeta;
     #[derive(Clone, Default)]
-    pub struct DefaultDomainWebsocketConnector {
-    }
+    pub struct DefaultDomainWebsocketConnector {}
     impl DefaultDomainWebsocketConnector {
         pub fn new() -> Self {
             Self {}
@@ -115,7 +112,6 @@ mod wasm_connector {
             "localhost"
         }
     }
-
 }
 
 #[cfg(unix)]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -104,7 +104,7 @@ mod wasm_connector {
             &self,
             addr: &str,
         ) -> Result<(BoxWriteConnection, BoxReadConnection, ConnectionFd), IoError> {
-            let (mut _ws, wsstream) = WsMeta::connect(addr, None).await.unwrap();
+            let (mut _ws, wsstream) = WsMeta::connect(addr, None).await.map_err(|e| IoError::new(std::io::ErrorKind::Other, e))?;
             let wsstream_clone = wsstream.clone();
             Ok((
                 Box::new(wsstream.into_io()),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -41,10 +41,10 @@ mod conn {
             impl<T: AsyncWrite + Unpin> WriteConnection for T {}
         }
     }
-
-    pub type BoxConnection = Box<dyn Connection>;
-    pub type BoxReadConnection = Box<dyn ReadConnection>;
+    pub type BoxConnection      = Box<dyn Connection>;
+    pub type BoxReadConnection  = Box<dyn ReadConnection>;
     pub type BoxWriteConnection = Box<dyn WriteConnection>;
+
 
     pub trait SplitConnection {
         // split into write and read
@@ -100,10 +100,11 @@ mod wasm_connector {
             &self,
             addr: &str,
         ) -> Result<(BoxWriteConnection, BoxReadConnection, ConnectionFd), IoError> {
-            let (mut _ws, wsstream) = WsMeta::connect("ws://127.0.0.1:3012", None).await.unwrap();
-            let (mut _ws, wsstream2) = WsMeta::connect("ws://127.0.0.1:3012", None).await.unwrap();
-            Ok((Box::new(wsstream.into_io()), Box::new(wsstream2.into_io()), addr.into()))
-            //unimplemented!()
+            let (mut _ws, wsstream) = WsMeta::connect(addr, None).await.unwrap();
+            // wsstream implements both AsyncRead and AsyncWrite but there's not a good way to
+            // split them.
+            let _wsstream = wsstream.into_io();
+            unimplemented!();
         }
 
         fn new_domain(&self, _domain: String) -> DomainConnector {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -20,14 +20,27 @@ mod conn {
     use async_trait::async_trait;
     use futures_lite::io::{AsyncRead, AsyncWrite};
 
-    pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection {}
-    impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection> Connection for T {}
+    cfg_if::cfg_if! {
+        if #[cfg(not(target_arch = "wasm32"))] {
+            pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection {}
+            impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection> Connection for T {}
 
-    pub trait ReadConnection: AsyncRead + Send + Sync + Unpin {}
-    impl<T: AsyncRead + Send + Sync + Unpin> ReadConnection for T {}
+            pub trait ReadConnection: AsyncRead + Send + Sync + Unpin {}
+            impl<T: AsyncRead + Send + Sync + Unpin> ReadConnection for T {}
 
-    pub trait WriteConnection: AsyncWrite + Send + Sync + Unpin {}
-    impl<T: AsyncWrite + Send + Sync + Unpin> WriteConnection for T {}
+            pub trait WriteConnection: AsyncWrite + Send + Sync + Unpin {}
+            impl<T: AsyncWrite + Send + Sync + Unpin> WriteConnection for T {}
+        } else if #[cfg(target_arch = "wasm32")] {
+            pub trait Connection: AsyncRead + AsyncWrite + Unpin + SplitConnection {}
+            impl<T: AsyncRead + AsyncWrite  + Unpin + SplitConnection> Connection for T {}
+
+            pub trait ReadConnection: AsyncRead + Unpin {}
+            impl<T: AsyncRead + Unpin> ReadConnection for T {}
+
+            pub trait WriteConnection: AsyncWrite + Unpin {}
+            impl<T: AsyncWrite + Unpin> WriteConnection for T {}
+        }
+    }
 
     pub type BoxConnection = Box<dyn Connection>;
     pub type BoxReadConnection = Box<dyn ReadConnection>;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -10,6 +10,13 @@ pub use conn::*;
 #[cfg(unix)]
 pub use unix_connector::DefaultTcpDomainConnector as DefaultDomainConnector;
 
+#[cfg(unix)]
+#[deprecated(
+    since = "0.3.3",
+    note = "Please use the bar DefaultDomainConnector"
+)]
+pub use unix_connector::DefaultTcpDomainConnector;
+
 #[cfg(target_arch = "wasm32")]
 pub use wasm_connector::DefaultDomainWebsocketConnector as DefaultDomainConnector;
 


### PR DESCRIPTION
Removed the `Send + Sync` constraints on traits for wasm and started the WebSocketConnector.

The [`IoStream`](https://docs.rs/async_io_stream/0.3.0/async_io_stream/struct.IoStream.html) implements `AsyncRead` and `AsyncWrite` but I'm not sure how to split them.