### PR TITLE
[Merged by Bors] - feat: partial CA trust anchor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"

--- a/certs/Makefile
+++ b/certs/Makefile
@@ -5,30 +5,65 @@ setup:
 	mkdir -p test-certs
 
 
-generate-certs:	setup generate-ca-crt generate-server-crt generate-client-crt generate-pk12-certs
+generate-certs:	setup generate-ca-crt generate-intermediate-ca-crt generate-server-crt generate-intermediate-chain generate-client-crt generate-pk12-certs
 
 # run generate-certs first
 generate-pk12-certs:	generate-server-pk12 generate-client-pk12
 
+### CA Generation
+
 generate-ca-key:	
 	openssl genrsa  -out test-certs/ca.key 4096
 
-# this is CA pem file
 generate-ca-crt:	generate-ca-key
 	openssl req -x509 -new -nodes -key test-certs/ca.key -out test-certs/ca.crt \
 		-subj /C=US/ST=CA/L=Sunnyvale/O=Fluvio/OU=Eng/CN=fluvio.io
 
+### Intermediate CA Generation
 
+generate-intermediate-ca-key:	
+	openssl genrsa  -out test-certs/intermediate-ca.key 4096
 
-generate-server-key:	
+generate-intermediate-ca-csr: generate-intermediate-ca-key
+	openssl req -new \
+    -key test-certs/intermediate-ca.key \
+    -out test-certs/intermediate-ca.csr \
+    -subj /C=US/ST=CA/L=Sunnyvale/O=Fluvio/OU=Eng/CN=intermediate.fluvio.io \
+    -config intermediate-cert.conf
+
+generate-intermediate-ca-crt: generate-intermediate-ca-csr
+	openssl x509 -req \
+    -in test-certs/intermediate-ca.csr \
+    -out test-certs/intermediate-ca.crt \
+		-CA test-certs/ca.crt \
+		-CAkey test-certs/ca.key \
+		-CAcreateserial  \
+		-days 500 \
+		-extensions v3_inter \
+		-extfile openssl.cnf
+
+### Non-Intermediate Chain Server
+
+generate-server-key:
 	openssl genrsa -out test-certs/server.key 4096
 
 
 generate-server-csr:	generate-server-key
 	openssl req -new -key test-certs/server.key \
 		-out test-certs/server.csr \
-		-config  cert.conf 
+		-config  cert.conf
 
+
+### Intermediate Chain Server
+
+generate-intermediate-server-key:	
+	openssl genrsa -out test-certs/intermediate-server.key 4096
+
+
+generate-intermediate-server-csr:	generate-intermediate-server-key
+	openssl req -new -key test-certs/intermediate-server.key \
+		-out test-certs/intermediate-server.csr \
+		-config  cert.conf 
 
 # generate anonymous pk12
 .PHONY: generate-server-pk12
@@ -39,6 +74,8 @@ generate-server-pk12:
 
 verify-csr:
 	openssl req -in test-certs/server.csr -noout -text
+
+### Non-Intermediate Chain
 
 decrypt-server-crt:
 	openssl x509 -in test-certs/server.crt   -noout -text
@@ -54,6 +91,29 @@ generate-server-crt:	generate-server-csr
 		-extensions v3_end \
 		-extfile openssl.cnf
 
+### Intermediate Chain
+
+decrypt-intermediate-server-crt:
+	openssl x509 -in test-certs/intermediate-server.crt   -noout -text
+
+generate-intermediate-server-crt:	generate-intermediate-server-csr
+	openssl x509 -req \
+		-in test-certs/intermediate-server.csr \
+		-out test-certs/intermediate-server.crt \
+		-CA test-certs/intermediate-ca.crt \
+		-CAkey test-certs/intermediate-ca.key \
+		-CAcreateserial  \
+		-days 500 \
+		-extensions v3_end \
+		-extfile openssl.cnf
+
+generate-intermediate-chain: generate-intermediate-ca-crt generate-intermediate-server-crt
+	cat test-certs/ca.crt test-certs/intermediate-ca.crt test-certs/intermediate-server.crt > test-certs/intermediate-full.crt
+
+#################################
+#
+#  Client Certificates
+#
 
 generate-client-key:
 	openssl genrsa -out test-certs/client.key 4096
@@ -88,7 +148,10 @@ test-mac-curl:
 MAKE_DIR = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 start-nginx:
-	nginx -c $(MAKE_DIR)/nginx.conf 
+	nginx -c $(MAKE_DIR)/nginx.conf
+
+start-intermediate-nginx:
+	nginx -c $(MAKE_DIR)/intermediate-nginx.conf 
 
 stop-nginx:
 	nginx -s quit

--- a/certs/intermediate-cert.conf
+++ b/certs/intermediate-cert.conf
@@ -1,0 +1,21 @@
+[req]
+default_bits = 4096
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+C=US
+ST=CA
+L=Sunnyvale
+O=End Point
+OU=Testing Intermediate Domain
+emailAddress=test@fluvio.io
+CN = intermediate.fluvio.io
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = intermediate-ca

--- a/certs/intermediate-nginx.conf
+++ b/certs/intermediate-nginx.conf
@@ -1,0 +1,28 @@
+worker_processes  1;
+
+daemon off;
+
+events {
+  multi_accept        on;
+}
+
+http {
+  sendfile           on;
+  tcp_nopush         on;
+  tcp_nodelay        on;
+
+  error_log stderr info;
+
+  # Upstream
+  server {
+    listen 8443 ssl;
+    server_name _;
+
+    ssl_certificate         test-certs/intermediate-server.crt;
+    ssl_certificate_key     test-certs/intermediate-server.key;
+
+    location / {
+      return 200 "\rhello!";
+    }
+  }
+}

--- a/src/openssl/connector.rs
+++ b/src/openssl/connector.rs
@@ -220,13 +220,11 @@ impl TlsConnectorBuilder {
         mut self,
         ca_file: P,
     ) -> Result<TlsConnectorBuilder> {
-        self.allow_partial = true;
         self.inner.set_ca_file(ca_file)?;
         Ok(self)
     }
 
     pub fn add_root_certificate(mut self, cert: Certificate) -> Result<TlsConnectorBuilder> {
-        self.allow_partial = true;
         self.inner.cert_store_mut().add_cert(cert.0)?;
         Ok(self)
     }

--- a/src/openssl/connector.rs
+++ b/src/openssl/connector.rs
@@ -178,7 +178,7 @@ impl TlsConnector {
             let params = client_configuration.param_mut();
             params.set_flags(X509VerifyFlags::PARTIAL_CHAIN)?;
         }
-        
+
         HandshakeFuture::Initial(
             move |stream| client_configuration.connect(domain, stream),
             AsyncToSyncWrapper::new(stream),

--- a/src/openssl/connector.rs
+++ b/src/openssl/connector.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use futures_lite::io::{AsyncRead, AsyncWrite};
 use log::debug;
 use openssl::ssl;
+use openssl::x509::verify::X509VerifyFlags;
 
 use crate::net::{
     AsConnectionFd, BoxReadConnection, BoxWriteConnection, ConnectionFd, DomainConnector,
@@ -150,6 +151,7 @@ pub mod certs {
 pub struct TlsConnector {
     pub inner: ssl::SslConnector,
     pub verify_hostname: bool,
+    pub allow_partial: bool,
 }
 
 impl TlsConnector {
@@ -158,6 +160,7 @@ impl TlsConnector {
         Ok(TlsConnectorBuilder {
             inner,
             verify_hostname: true,
+            allow_partial: true,
         })
     }
 
@@ -166,10 +169,16 @@ impl TlsConnector {
         S: AsyncRead + AsyncWrite + fmt::Debug + Unpin + Send + Sync + 'static,
     {
         debug!("tls connecting to: {}", domain);
-        let client_configuration = self
+        let mut client_configuration = self
             .inner
             .configure()?
             .verify_hostname(self.verify_hostname);
+
+        if self.allow_partial {
+            let params = client_configuration.param_mut();
+            params.set_flags(X509VerifyFlags::PARTIAL_CHAIN)?;
+        }
+        
         HandshakeFuture::Initial(
             move |stream| client_configuration.connect(domain, stream),
             AsyncToSyncWrapper::new(stream),
@@ -181,6 +190,7 @@ impl TlsConnector {
 pub struct TlsConnectorBuilder {
     inner: ssl::SslConnectorBuilder,
     verify_hostname: bool,
+    allow_partial: bool,
 }
 
 impl TlsConnectorBuilder {
@@ -210,11 +220,13 @@ impl TlsConnectorBuilder {
         mut self,
         ca_file: P,
     ) -> Result<TlsConnectorBuilder> {
+        self.allow_partial = true;
         self.inner.set_ca_file(ca_file)?;
         Ok(self)
     }
 
     pub fn add_root_certificate(mut self, cert: Certificate) -> Result<TlsConnectorBuilder> {
+        self.allow_partial = true;
         self.inner.cert_store_mut().add_cert(cert.0)?;
         Ok(self)
     }
@@ -234,6 +246,7 @@ impl TlsConnectorBuilder {
         TlsConnector {
             inner: self.inner.build(),
             verify_hostname: self.verify_hostname,
+            allow_partial: self.allow_partial,
         }
     }
 }


### PR DESCRIPTION
Closes #135

This proposed feature adds to TlsClient constructor:
- `allow_partial: bool` which toggles OpenSSL [X509VerifyFlags::PARTIAL_CHAIN](https://docs.rs/openssl/latest/openssl/x509/verify/struct.X509VerifyFlags.html#associatedconstant.PARTIAL_CHAIN) - default `true`

### Publish

This PR bumps fluvio-futures to 0.3.14

Enables bump in k8-client:
- https://github.com/infinyon/k8-api/pull/151

Which in turn enables bump in fluvio:
- https://github.com/infinyon/fluvio/pull/2232
