### PR TITLE
[Merged by Bors] - Use ws_stream_wasm version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "async-fs",
  "async-io",
@@ -364,7 +364,6 @@ dependencies = [
  "fluvio-future",
  "fluvio-test-derive",
  "fluvio-wasm-timer",
- "fluvio_ws_stream_wasm",
  "flv-util",
  "futures-lite",
  "futures-timer",
@@ -390,6 +389,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "webpki",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -411,24 +411,6 @@ dependencies = [
  "js-sys",
  "parking_lot",
  "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "fluvio_ws_stream_wasm"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9875a7ffd1467f052ee51d936dc916f3b040ee3989d6abc875a10f0d2b204cdf"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "pharos",
- "rustc_version 0.3.3",
- "send_wrapper",
- "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -851,22 +833,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1052,20 +1025,11 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.5",
+ "semver",
 ]
 
 [[package]]
@@ -1138,27 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "send_wrapper"
@@ -1401,12 +1347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,3 +1574,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ca1ab42f5afed7fc332b22b6e932ca5414b209465412c8cdf0ad23bc0de645"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"
@@ -14,7 +14,7 @@ subscriber = ["tracing-subscriber", "tracing-subscriber/std", "tracing-subscribe
 fixture = ["subscriber", "task", "fluvio-test-derive"]
 task_unstable = ["task", "async-std/unstable"]
 io = ["async-std/default"]
-net = ["futures-lite", "async-net", "async-trait", "cfg-if"]
+net = ["futures-lite", "async-net", "async-trait", "cfg-if", "futures-util/io"]
 tls = ["rust_tls"]
 rust_tls = [
     "net",
@@ -78,7 +78,7 @@ openssl-sys = { version = "0.9.65", optional = true, features = ["vendored"]}
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fluvio-wasm-timer = "0.2.5"
 async-std = { version = "1.6.2", default-features = false, features = ["unstable"], optional = true }
-fluvio_ws_stream_wasm = "0.7.0"
+ws_stream_wasm = "0.7.3"
 
 [dev-dependencies]
 bytes = "1.0.0"

--- a/async-test-derive/src/lib.rs
+++ b/async-test-derive/src/lib.rs
@@ -1,21 +1,19 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::ItemFn;
-use syn::Ident;
 use proc_macro2::Span;
-
+use quote::quote;
+use syn::Ident;
+use syn::ItemFn;
 
 #[proc_macro_attribute]
 pub fn test_async(args: TokenStream, item: TokenStream) -> TokenStream {
-
     use syn::AttributeArgs;
 
     let attribute_args = syn::parse_macro_input!(args as AttributeArgs);
     let input = syn::parse_macro_input!(item as ItemFn);
     let name = &input.sig.ident;
-    let sync_name = format!("{}_sync",name);
+    let sync_name = format!("{}_sync", name);
     let out_fn_iden = Ident::new(&sync_name, Span::call_site());
 
     let test_attributes = generate::generate_test_attributes(&attribute_args);
@@ -45,19 +43,16 @@ pub fn test_async(args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     expression.into()
-
 }
-
 
 #[proc_macro_attribute]
 pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
-
     use syn::AttributeArgs;
 
     let attribute_args = syn::parse_macro_input!(args as AttributeArgs);
     let input = syn::parse_macro_input!(item as ItemFn);
     let name = &input.sig.ident;
-    let sync_name = format!("{}_sync",name);
+    let sync_name = format!("{}_sync", name);
     let out_fn_iden = Ident::new(&sync_name, Span::call_site());
 
     let test_attributes = generate::generate_test_attributes(&attribute_args);
@@ -76,26 +71,22 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
                 #name().await;
             };
 
-            
+
             ::fluvio_future::task::run_block_on(ft);
 
         }
     };
 
     expression.into()
-
 }
-
-
 
 mod generate {
 
     use proc_macro2::TokenStream;
-    use syn::NestedMeta;
     use quote::quote;
+    use syn::NestedMeta;
 
     pub fn generate_test_attributes(attributes: &Vec<NestedMeta>) -> TokenStream {
-        
         let args = attributes.iter().map(|meta| {
             quote! {
                 #[#meta]


### PR DESCRIPTION
With this change we no longer need our fork of ws_stream_wasm. This implementation is still ?Send, 