### PR TITLE
[Merged by Bors] - Make all net connections send + sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 0.3.17
+* Added wasm32 `Send + Sync` contraints for `Connection` ([#149](https://github.com/infinyon/future-aio/pull/149/))
+
 ## 0.3.14 - 2022-03-08
 * Add Intermediate CA Trust Anchor ([#135](https://github.com/infinyon/future-aio/issues/135))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.3.16"
+version = "0.3.17"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -23,28 +23,15 @@ mod conn {
 
     use async_trait::async_trait;
     use futures_lite::io::{AsyncRead, AsyncWrite};
+    pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection {}
+    impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection> Connection for T {}
 
-    cfg_if::cfg_if! {
-        if #[cfg(not(target_arch = "wasm32"))] {
-            pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection {}
-            impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection> Connection for T {}
+    pub trait ReadConnection: AsyncRead + Send + Sync + Unpin {}
+    impl<T: AsyncRead + Send + Sync + Unpin> ReadConnection for T {}
 
-            pub trait ReadConnection: AsyncRead + Send + Sync + Unpin {}
-            impl<T: AsyncRead + Send + Sync + Unpin> ReadConnection for T {}
+    pub trait WriteConnection: AsyncWrite + Send + Sync + Unpin {}
+    impl<T: AsyncWrite + Send + Sync + Unpin> WriteConnection for T {}
 
-            pub trait WriteConnection: AsyncWrite + Send + Sync + Unpin {}
-            impl<T: AsyncWrite + Send + Sync + Unpin> WriteConnection for T {}
-        } else if #[cfg(target_arch = "wasm32")] {
-            pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection {}
-            impl<T: AsyncRead + AsyncWrite  + Unpin + SplitConnection + Send + Sync> Connection for T {}
-
-            pub trait ReadConnection: AsyncRead + Unpin + Send + Sync {}
-            impl<T: AsyncRead + Unpin + Send + Sync> ReadConnection for T {}
-
-            pub trait WriteConnection: AsyncWrite + Unpin + Send + Sync {}
-            impl<T: AsyncWrite + Unpin + Send + Sync> WriteConnection for T {}
-        }
-    }
     pub type BoxConnection = Box<dyn Connection>;
     pub type BoxReadConnection = Box<dyn ReadConnection>;
     pub type BoxWriteConnection = Box<dyn WriteConnection>;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -35,14 +35,14 @@ mod conn {
             pub trait WriteConnection: AsyncWrite + Send + Sync + Unpin {}
             impl<T: AsyncWrite + Send + Sync + Unpin> WriteConnection for T {}
         } else if #[cfg(target_arch = "wasm32")] {
-            pub trait Connection: AsyncRead + AsyncWrite + Unpin + SplitConnection {}
-            impl<T: AsyncRead + AsyncWrite  + Unpin + SplitConnection> Connection for T {}
+            pub trait Connection: AsyncRead + AsyncWrite + Send + Sync + Unpin + SplitConnection {}
+            impl<T: AsyncRead + AsyncWrite  + Unpin + SplitConnection + Send + Sync> Connection for T {}
 
-            pub trait ReadConnection: AsyncRead + Unpin {}
-            impl<T: AsyncRead + Unpin> ReadConnection for T {}
+            pub trait ReadConnection: AsyncRead + Unpin + Send + Sync {}
+            impl<T: AsyncRead + Unpin + Send + Sync> ReadConnection for T {}
 
-            pub trait WriteConnection: AsyncWrite + Unpin {}
-            impl<T: AsyncWrite + Unpin> WriteConnection for T {}
+            pub trait WriteConnection: AsyncWrite + Unpin + Send + Sync {}
+            impl<T: AsyncWrite + Unpin + Send + Sync> WriteConnection for T {}
         }
     }
     pub type BoxConnection = Box<dyn Connection>;


### PR DESCRIPTION
It seems that having the connections not be `Send + Sync` isn't needed anymore. I've tested that fluvio-client-wasm compiles with these changes.