### PR TITLE
[Merged by Bors] - Upgrade `rustls` & `fluvio-async-tls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,8 @@ dependencies = [
 [[package]]
 name = "fluvio-async-tls"
 version = "0.3.0"
-source = "git+https://github.com/infinyon/fluvio-async-tls?rev=6c920c8#6c920c8949f85df87d82a917f4978810e18c2214"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab83884d2a39e57047387dc20a62cf6e28d1e3212591ad64826c4dbb5dfa76"
 dependencies = [
  "futures-core",
  "futures-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.3.18"
+version = "0.4.0"
 dependencies = [
  "async-fs",
  "async-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,8 +336,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio-async-tls"
-version = "0.2.0"
-source = "git+https://github.com/heilhead/fluvio-async-tls.git?rev=94a8cf7#94a8cf7f4ea9ae1b6d8e54ed973db88ca9b1d532"
+version = "0.3.0"
+source = "git+https://github.com/infinyon/fluvio-async-tls?rev=6c920c8#6c920c8949f85df87d82a917f4978810e18c2214"
 dependencies = [
  "futures-core",
  "futures-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,13 +337,13 @@ dependencies = [
 [[package]]
 name = "fluvio-async-tls"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54126ce6fe585aea438300ad7ae143a6798770314b2c44485e1626be776bedc1"
+source = "git+https://github.com/heilhead/fluvio-async-tls.git?rev=baf83a0#baf83a0c21d4cd13905cea12d0abb157b680ab49"
 dependencies = [
  "futures-core",
  "futures-io",
  "rustls",
- "webpki",
+ "rustls-pemfile",
+ "webpki 0.22.0",
  "webpki-roots",
 ]
 
@@ -380,6 +380,7 @@ dependencies = [
  "pin-utils",
  "portpicker",
  "rustls",
+ "rustls-pemfile",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -388,7 +389,7 @@ dependencies = [
  "tracing-wasm",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "webpki",
+ "webpki 0.21.4",
  "ws_stream_wasm",
 ]
 
@@ -1034,15 +1035,23 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
- "base64",
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1069,9 +1078,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -1536,12 +1545,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.21.1"
+name = "webpki"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
- "webpki",
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "fluvio-async-tls"
 version = "0.2.0"
-source = "git+https://github.com/heilhead/fluvio-async-tls.git?rev=baf83a0#baf83a0c21d4cd13905cea12d0abb157b680ab49"
+source = "git+https://github.com/heilhead/fluvio-async-tls.git?rev=94a8cf7#94a8cf7f4ea9ae1b6d8e54ed973db88ca9b1d532"
 dependencies = [
  "futures-core",
  "futures-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.3.18"
+version = "0.4.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ async-trait = { version = "0.1.40", optional = true }
 webpki = { version = "0.21", optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
-fluvio-async-tls = { git = "https://github.com/infinyon/fluvio-async-tls", rev = "6c920c8", optional = true }
+fluvio-async-tls = { version = "0.3.0", optional = true }
 thiserror = "1.0.20"
 fluvio-test-derive = { path = "async-test-derive", version = "0.1.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ async-trait = { version = "0.1.40", optional = true }
 webpki = { version = "0.21", optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
-fluvio-async-tls = { git = "https://github.com/heilhead/fluvio-async-tls.git", rev = "baf83a0", optional = true }
+fluvio-async-tls = { git = "https://github.com/heilhead/fluvio-async-tls.git", rev = "94a8cf7", optional = true }
 thiserror = "1.0.20"
 fluvio-test-derive = { path = "async-test-derive", version = "0.1.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ async-trait = { version = "0.1.40", optional = true }
 webpki = { version = "0.21", optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
-fluvio-async-tls = { git = "https://github.com/heilhead/fluvio-async-tls.git", rev = "94a8cf7", optional = true }
+fluvio-async-tls = { git = "https://github.com/infinyon/fluvio-async-tls", rev = "6c920c8", optional = true }
 thiserror = "1.0.20"
 fluvio-test-derive = { path = "async-test-derive", version = "0.1.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tls = ["rust_tls"]
 rust_tls = [
     "net",
     "rustls",
+    "rustls-pemfile",
     "webpki",
     "fluvio-async-tls",
     "pin-project",
@@ -64,7 +65,7 @@ async-trait = { version = "0.1.40", optional = true }
 webpki = { version = "0.21", optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
-fluvio-async-tls = { version = "0.2.0", optional = true }
+fluvio-async-tls = { git = "https://github.com/heilhead/fluvio-async-tls.git", rev = "baf83a0", optional = true }
 thiserror = "1.0.20"
 fluvio-test-derive = { path = "async-test-derive", version = "0.1.1", optional = true }
 
@@ -76,7 +77,8 @@ memmap = { version = "0.7.0", optional = true }
 openssl = { version = "0.10.35", optional = true }
 async-native-tls = { version = "0.4.0", optional = true }
 native-tls = { version = "0.2.4", optional = true }
-rustls = { version = "0.19.0", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.20.6", features = ["dangerous_configuration"], optional = true }
+rustls-pemfile = { version = "1.0.0", optional = true }
 openssl-sys = { version = "0.9.65", optional = true, features = ["vendored"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/rust_tls.rs
+++ b/src/rust_tls.rs
@@ -228,7 +228,7 @@ mod builder {
     pub struct ConnectorBuilder;
 
     impl ConnectorBuilder {
-        pub fn new() -> ConnectorBuilderStage<WantsVerifier> {
+        pub fn with_safe_defaults() -> ConnectorBuilderStage<WantsVerifier> {
             ConnectorBuilderStage(ClientConfig::builder().with_safe_defaults())
         }
     }
@@ -329,7 +329,7 @@ mod builder {
     pub struct AcceptorBuilder;
 
     impl AcceptorBuilder {
-        pub fn new() -> AcceptorBuilderStage<WantsVerifier> {
+        pub fn with_safe_defaults() -> AcceptorBuilderStage<WantsVerifier> {
             AcceptorBuilderStage(ServerConfig::builder().with_safe_defaults())
         }
     }
@@ -438,11 +438,13 @@ mod test {
     #[test_async]
     async fn test_async_tls() -> Result<(), IoError> {
         test_tls(
-            AcceptorBuilder::new()
+            AcceptorBuilder::with_safe_defaults()
                 .no_client_authentication()
                 .load_server_certs("certs/test-certs/server.crt", "certs/test-certs/server.key")?
                 .build(),
-            ConnectorBuilder::new().no_cert_verification().build(),
+            ConnectorBuilder::with_safe_defaults()
+                .no_cert_verification()
+                .build(),
         )
         .await
         .expect("no client cert test failed");
@@ -450,11 +452,11 @@ mod test {
         // test client authentication
 
         test_tls(
-            AcceptorBuilder::new()
+            AcceptorBuilder::with_safe_defaults()
                 .client_authenticate(CA_PATH)?
                 .load_server_certs("certs/test-certs/server.crt", "certs/test-certs/server.key")?
                 .build(),
-            ConnectorBuilder::new()
+            ConnectorBuilder::with_safe_defaults()
                 .load_ca_cert(CA_PATH)?
                 .load_client_certs("certs/test-certs/client.crt", "certs/test-certs/client.key")?
                 .build(),

--- a/src/rust_tls.rs
+++ b/src/rust_tls.rs
@@ -76,11 +76,11 @@ mod cert {
             .map_err(|_| IoError::new(ErrorKind::InvalidInput, "invalid key"))
     }
 
-    pub fn load_first_key<P: AsRef<Path>>(path: P) -> Result<PrivateKey, IoError> {
+    pub(crate) fn load_first_key<P: AsRef<Path>>(path: P) -> Result<PrivateKey, IoError> {
         load_first_key_from_reader(&mut BufReader::new(File::open(path)?))
     }
 
-    pub fn load_first_key_from_reader(rd: &mut dyn BufRead) -> Result<PrivateKey, IoError> {
+    pub(crate) fn load_first_key_from_reader(rd: &mut dyn BufRead) -> Result<PrivateKey, IoError> {
         let mut keys = load_keys_from_reader(rd)?;
 
         if keys.is_empty() {


### PR DESCRIPTION
Fixes https://github.com/infinyon/future-aio/issues/125

This upgrades `rustls` to `0.20.6`.

Comes with breaking changes to `rust_tls::builder::ConnectorBuilder` and `rust_tls::builder::AcceptorBuilder`, which now follow the builder stages pattern from the `rustls` config builder.

Note: I wasn't able to verify changes with the tests from `rust_tls` module, since `certs/test-certs` are gitignored and I don't have access to the required certificates/keys.

Note: Requires https://github.com/infinyon/fluvio-async-tls/pull/3 to be merged and published first, so that we can update the dependency in this crate.