### PR TITLE
Fix missing dependency of fs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ openssl_tls = [
     "futures-util/io",
 ]
 timer = ["async-io", "pin-project", "futures-lite"]
-fs = ["async-fs", "futures-lite", "pin-utils"]
+fs = ["async-fs", "futures-lite", "pin-utils", "async-trait"]
 zero_copy = ["nix", "task_unstable"]
 mmap = ["fs", "memmap", "task_unstable"]
 retry = []


### PR DESCRIPTION
Currently `cargo build --features fs` fails with:
```rust
error[E0706]: functions in traits cannot be declared `async`
  --> src/fs/extension.rs:21:5
   |
21 |     async fn reset_to_beginning(&mut self) -> Result<(), IoError>;
   |     -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     `async` because of this
   |
   = note: `async` trait functions are not currently supported
   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
```