### PR TITLE
[Merged by Bors] - Make tcp connector send for wasm32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 0.4.1
+* Make tcp connector `Send` for `wasm32` ([#165](https://github.com/infinyon/future-aio/pull/165))
+
 ## 0.4.0
 * Upgrade Rustls results in AcceptorBuilder and ConnectorBuilder API changes ([#151](https://github.com/infinyon/future-aio/pull/154))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-fs",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -65,16 +65,9 @@ mod conn {
 
     pub type DomainConnector = Box<dyn TcpDomainConnector>;
 
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "wasm32")] {
-            pub trait AsyncConnector {}
-            impl <T: TcpDomainConnector> AsyncConnector for T {}
-        } else {
-            pub trait AsyncConnector: Send + Sync {}
+    pub trait AsyncConnector: Send + Sync {}
 
-            impl<T: Send + Sync> AsyncConnector for T {}
-        }
-    }
+    impl<T: Send + Sync> AsyncConnector for T {}
 
     /// connect to domain and return connection
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -169,7 +169,7 @@ mod delay {
         }
     }
 
-    /// A retry strategy driven by the fibonacci series of intervals between retires.
+    /// A retry strategy driven by the fibonacci series of intervals between retries.
     /// ```
     /// use std::io::Error;
     /// use fluvio_future::retry::{FibonacciBackoff, retry};


### PR DESCRIPTION
`TcpDomainConnector` needs to be `Send` for using in async tasks up in the stack. Currently, it is only for non wasm32 targets.  This PR makes it `Send` for wasm32 as well.

Verified that `fluvio-client-wasm` compiles with this change.

Related to infinyon/fluvio#2481