### PR TITLE
[Merged by Bors] - feat: reimport async_std::sync structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-fs",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"
@@ -17,6 +17,7 @@ subscriber = ["tracing-subscriber", "tracing-subscriber/std", "tracing-subscribe
 fixture = ["subscriber", "task", "fluvio-test-derive"]
 task_unstable = ["task", "async-std/unstable"]
 io = ["async-std/default"]
+sync = ["async-std/default"]
 net = ["futures-lite", "async-net", "async-trait", "cfg-if", "futures-util/io"]
 tls = ["rust_tls"]
 rust_tls = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub use crate::native_tls as tls;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod openssl;
 
+#[cfg(feature = "sync")]
+pub mod sync;
+
 #[cfg(feature = "subscriber")]
 pub mod subscriber {
     use tracing_subscriber::EnvFilter;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,1 @@
+pub use async_std::sync::*;


### PR DESCRIPTION
Reimports all the async_std::sync structs. (CondVar, Mutex, RwLock...)

See image:

<img width="1053" alt="Screen Shot 2022-08-18 at 3 19 49 PM" src="https://user-images.githubusercontent.com/22335041/185476768-944243e6-00ac-49da-b549-2eae5b122e30.png">