### PR TITLE
[Merged by Bors] - feat: Doomsday timer to ensure crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-fs",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ fs = ["async-fs", "futures-lite", "pin-utils", "async-trait"]
 zero_copy = ["nix", "task_unstable"]
 mmap = ["fs", "memmap", "task_unstable"]
 retry = []
+doomsday = ["async-std/default"]
 
 [dependencies]
 log = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ fs = ["async-fs", "futures-lite", "pin-utils", "async-trait"]
 zero_copy = ["nix", "task_unstable"]
 mmap = ["fs", "memmap", "task_unstable"]
 retry = []
-doomsday = ["async-std/default"]
+doomsday = []
 
 [dependencies]
 log = "0.4.0"

--- a/async-test-derive/Cargo.lock
+++ b/async-test-derive/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-io",
  "async-std",

--- a/src/doomsday.rs
+++ b/src/doomsday.rs
@@ -60,7 +60,7 @@ impl DoomsdayTimer {
         }
     }
 
-    fn explode(&self) {
+    pub fn explode(&self) {
         error!("Boom. DoomsdayTimer has exploded");
         if self.aggressive_mode {
             std::process::exit(1);

--- a/src/doomsday.rs
+++ b/src/doomsday.rs
@@ -49,7 +49,7 @@ impl DoomsdayTimer {
         };
 
         let cloned = s.clone();
-        let jh = async_std::task::spawn(async move {
+        let jh = crate::task::spawn(async move {
             cloned.main_loop().await;
         });
         (s, jh)

--- a/src/doomsday.rs
+++ b/src/doomsday.rs
@@ -1,0 +1,86 @@
+use async_std::sync::Mutex;
+use async_std::task::JoinHandle;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tracing::error;
+
+#[derive(Clone)]
+pub struct DoomsdayTimer {
+    time_to_explode: Arc<Mutex<Instant>>,
+    duration: Duration,
+    aggressive_mode: bool,
+}
+
+impl DoomsdayTimer {
+    pub fn spawn_with_panic(duration: Duration) -> (Self, JoinHandle<()>) {
+        let s = Self {
+            time_to_explode: Arc::new(Mutex::new(Instant::now() + duration)),
+            duration,
+            aggressive_mode: false,
+        };
+
+        let cloned = s.clone();
+        let jh = async_std::task::spawn(async move {
+            cloned.main_loop().await;
+        });
+        (s, jh)
+    }
+
+    pub fn spawn_with_exit(duration: Duration) -> Self {
+        let s = Self {
+            time_to_explode: Arc::new(Mutex::new(Instant::now() + duration)),
+            duration,
+            aggressive_mode: false,
+        };
+
+        let cloned = s.clone();
+        async_std::task::spawn(async move {
+            cloned.main_loop().await;
+        });
+        s
+    }
+
+    pub async fn reset(&self) {
+        let new_time_to_explode = Instant::now() + self.duration;
+        *self.time_to_explode.lock().await = new_time_to_explode;
+    }
+
+    async fn main_loop(&self) {
+        loop {
+            let now = Instant::now();
+            let time_to_explode = *self.time_to_explode.lock().await;
+            if now > time_to_explode {
+                self.explode();
+            } else {
+                let time_to_sleep = time_to_explode - now;
+                async_std::task::sleep(time_to_sleep).await;
+            }
+        }
+    }
+
+    fn explode(&self) {
+        error!("Boom. DoomsdayTimer has exploded");
+        if self.aggressive_mode {
+            std::process::exit(1);
+        } else {
+            panic!("DoomsdayTimer with Duration {:?} exploded", self.duration);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::DoomsdayTimer;
+
+    #[test]
+    #[should_panic]
+    fn test_explode() {
+        let (_, jh) = DoomsdayTimer::spawn_with_panic(Duration::from_millis(1));
+        std::thread::sleep(Duration::from_millis(2));
+        async_std::task::block_on(jh)
+    }
+}

--- a/src/doomsday.rs
+++ b/src/doomsday.rs
@@ -65,7 +65,7 @@ impl DoomsdayTimer {
         };
 
         let cloned = s.clone();
-        async_std::task::spawn(async move {
+        crate::task::spawn(async move {
             cloned.main_loop().await;
         });
         s
@@ -91,7 +91,7 @@ impl DoomsdayTimer {
                 self.explode_inner();
             } else {
                 let time_to_sleep = time_to_explode - now;
-                async_std::task::sleep(time_to_sleep).await;
+                crate::timer::sleep(time_to_sleep).await;
             }
         }
     }

--- a/src/doomsday.rs
+++ b/src/doomsday.rs
@@ -107,13 +107,14 @@ mod tests {
     use std::time::Duration;
 
     use super::DoomsdayTimer;
+    use crate::task::run_block_on;
     use crate::test_async;
     use std::io::Error;
 
     #[test_async(should_panic)]
     async fn test_explode() -> Result<(), Error> {
         let (_, jh) = DoomsdayTimer::spawn(Duration::from_millis(1), false);
-        async_std::task::sleep(Duration::from_millis(2)).await;
+        crate::timer::sleep(Duration::from_millis(2)).await;
         jh.await;
         Ok(())
     }
@@ -121,13 +122,13 @@ mod tests {
     #[test_async]
     async fn test_do_not_explode() -> Result<(), Error> {
         let (bomb, jh) = DoomsdayTimer::spawn(Duration::from_millis(10), false);
-        async_std::task::sleep(Duration::from_millis(5)).await;
+        crate::timer::sleep(Duration::from_millis(5)).await;
         bomb.reset().await;
-        async_std::task::sleep(Duration::from_millis(5)).await;
+        crate::timer::sleep(Duration::from_millis(5)).await;
         bomb.reset().await;
-        async_std::task::sleep(Duration::from_millis(5)).await;
+        crate::timer::sleep(Duration::from_millis(5)).await;
         bomb.defuse();
-        async_std::task::block_on(jh);
+        run_block_on(jh);
         Ok(())
     }
 }

--- a/src/doomsday.rs
+++ b/src/doomsday.rs
@@ -61,7 +61,7 @@ impl DoomsdayTimer {
             time_to_explode: Arc::new(Mutex::new(Instant::now() + duration)),
             duration,
             defused: Default::default(),
-            aggressive_mode: false,
+            aggressive_mode: true,
         };
 
         let cloned = s.clone();

--- a/src/doomsday.rs
+++ b/src/doomsday.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_std::sync::Mutex;
-use async_std::task::JoinHandle;
+pub use async_std::task::JoinHandle;
 use tracing::error;
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub mod subscriber {
     }
 }
 
-// #[cfg(feature = "doomsday")]
+#[cfg(feature = "doomsday")]
 pub mod doomsday;
 
 /// re-export tracing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub mod subscriber {
     }
 }
 
-#[cfg(feature = "doomsday")]
+// #[cfg(feature = "doomsday")]
 pub mod doomsday;
 
 /// re-export tracing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@ pub mod subscriber {
     }
 }
 
+#[cfg(feature = "doomsday")]
+pub mod doomsday;
+
 /// re-export tracing
 pub mod tracing {
 

--- a/src/zero_copy.rs
+++ b/src/zero_copy.rs
@@ -78,11 +78,11 @@ impl ZeroCopy {
                     ) {
                         Ok(bytes_transferred) => {
                             trace!("bytes transferred: {}", bytes_transferred);
-                            total_transferred += bytes_transferred as usize;
+                            total_transferred += bytes_transferred;
 
                             // zero bytes transferred means it's EOF
                             if bytes_transferred == 0 {
-                                return Ok(total_transferred as usize);
+                                return Ok(total_transferred);
                             }
 
                             if total_transferred < size as usize {
@@ -97,7 +97,7 @@ impl ZeroCopy {
                                     size
                                 );
 
-                                return Ok(total_transferred as usize);
+                                return Ok(total_transferred);
                             }
                         }
                         Err(err) => match err {


### PR DESCRIPTION
Flips the paradigm from crash if failure detected to crash if success not asserted.

This is valuable as we may fail to detect failure. Can be used for components that run in environments with automatic restarts.