### PR TITLE
[Merged by Bors] - feat: enable socket keepalive by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
  "polling",
  "rustix 0.37.23",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -420,6 +420,7 @@ dependencies = [
  "pin-utils",
  "portpicker",
  "rustls-pemfile",
+ "socket2 0.5.3",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -1327,6 +1328,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ task_unstable = ["task", "async-std/unstable"]
 io = ["async-std/default"]
 sync = ["async-std/default"]
 future = ["async-std/default"]
-net = ["futures-lite", "async-net", "async-trait", "cfg-if", "futures-util/io"]
+net = ["futures-lite", "async-net", "async-trait", "cfg-if", "futures-util/io", "socket2"]
 tls = ["rust_tls"]
 rust_tls = [
     "net",
@@ -79,6 +79,7 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 openssl-sys = { version = "0.9.65", optional = true, features = ["vendored"]}
 nix = { version = "0.26.0", optional = true }
 async-fs = { version = "1.3.0", optional = true }
+socket2 = { version = "0.5.3", default-features = false, features = ["all"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fluvio-wasm-timer = "0.2.5"

--- a/async-test-derive/Cargo.lock
+++ b/async-test-derive/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.4.5"
+version = "0.5.1"
 dependencies = [
  "async-io",
  "async-std",

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,9 +1,8 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub use async_net::*;
 
-#[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
-mod tcp_stream;
+pub mod tcp_stream;
 
 pub use conn::*;
 
@@ -158,6 +157,8 @@ mod unix_connector {
     use async_trait::async_trait;
     use log::debug;
 
+    use super::tcp_stream::stream;
+
     use super::*;
 
     impl SplitConnection for TcpStream {
@@ -183,7 +184,7 @@ mod unix_connector {
             addr: &str,
         ) -> Result<(BoxWriteConnection, BoxReadConnection, ConnectionFd), IoError> {
             debug!("connect to tcp addr: {}", addr);
-            let tcp_stream = TcpStream::connect(addr).await?;
+            let tcp_stream = stream(addr).await?;
 
             let fd = tcp_stream.as_connection_fd();
             Ok((Box::new(tcp_stream.clone()), Box::new(tcp_stream), fd))
@@ -209,8 +210,8 @@ mod test {
     use futures_util::AsyncReadExt;
     use log::debug;
 
+    use crate::net::tcp_stream::stream;
     use crate::net::TcpListener;
-    use crate::net::TcpStream;
     use crate::test_async;
     use crate::timer::sleep;
 
@@ -241,7 +242,7 @@ mod test {
 
         let client_ft = async {
             sleep(time::Duration::from_millis(100)).await;
-            let tcp_stream = TcpStream::connect(&addr).await.expect("test");
+            let tcp_stream = stream(&addr).await.expect("test");
             let (_read, _write) = tcp_stream.split();
         };
 

--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -1,73 +1,255 @@
-use std::io::Error;
-use std::net::SocketAddr;
-use std::time;
+use std::time::Duration;
 
-use bytes::Buf;
-use bytes::BufMut;
-use bytes::Bytes;
-use bytes::BytesMut;
-use futures_lite::future::zip;
-use futures_lite::stream::StreamExt;
-use futures_util::sink::SinkExt;
+use async_net::AsyncToSocketAddrs;
 
-use tokio_util::codec::BytesCodec;
-use tokio_util::codec::Framed;
-use tokio_util::compat::FuturesAsyncReadCompatExt;
+use socket2::SockRef;
+use socket2::TcpKeepalive;
+use tracing::debug;
 
-use log::debug;
-
-use crate::test_async;
-use crate::timer::sleep;
-
-use crate::net::TcpListener;
 use crate::net::TcpStream;
 
-fn to_bytes(bytes: Vec<u8>) -> Bytes {
-    let mut buf = BytesMut::with_capacity(bytes.len());
-    buf.put_slice(&bytes);
-    buf.freeze()
+/// This setting determines the time (in seconds) that a connection must be idle before the first keepalive packet is sent.
+/// The default value is 7200 seconds, or 2 hours. This means that if there is no data exchange on a connection for 2 hours,
+/// the system will send a keepalive packet to the remote host to check if the connection is still active
+const TCP_KEEPALIVE_TIME: Duration = Duration::from_secs(7200);
+/// This setting specifies the interval (in seconds) between successive keepalive packets if no response (acknowledgment)
+/// is received from the remote host. The default value is 75 seconds. If the first keepalive packet does not receive a response,
+/// the system will send additional keepalive packets every 75 seconds until it receives a response or reaches the maximum number
+/// of allowed probes (as defined by tcp_keepalive_probes).
+const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(75);
+/// This setting defines the maximum number of unacknowledged keepalive packets that the system will send before considering the connection dead.
+/// The default value is 9 probes. If the system sends 9 keepalive packets without receiving a response,
+/// it assumes the connection is dead and closes it.
+#[cfg(not(windows))]
+const TCP_KEEPALIVE_PROBES: u32 = 9;
+
+#[derive(Debug, Clone, Default)]
+pub struct SocketOpts {
+    pub nodelay: Option<bool>,
+    pub keepalive: Option<KeepaliveOpts>,
 }
 
-#[test_async]
-async fn test_async_tcp() -> Result<(), Error> {
-    let addr = "127.0.0.1:9998".parse::<SocketAddr>().expect("parse");
+#[derive(Debug, Clone)]
+pub struct KeepaliveOpts {
+    pub time: Option<Duration>,
+    pub interval: Option<Duration>,
+    #[cfg(not(windows))]
+    pub retries: Option<u32>,
+}
 
-    let server_ft = async {
-        debug!("server: binding");
-        let listener = TcpListener::bind(&addr).await?;
-        debug!("server: successfully binding. waiting for incoming");
-        let mut incoming = listener.incoming();
-        let stream = incoming.next().await.expect("no stream");
-        debug!("server: got connection from client");
-        let tcp_stream = stream?;
-        let mut framed = Framed::new(tcp_stream.compat(), BytesCodec::new());
-        debug!("server: sending values to client");
-        let data = vec![0x05, 0x0a, 0x63];
-        framed.send(to_bytes(data)).await?;
-        Ok(()) as Result<(), Error>
+#[cfg(not(windows))]
+impl Default for KeepaliveOpts {
+    fn default() -> Self {
+        Self {
+            time: Some(TCP_KEEPALIVE_TIME),
+            interval: Some(TCP_KEEPALIVE_INTERVAL),
+            retries: Some(TCP_KEEPALIVE_PROBES),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Default for KeepaliveOpts {
+    fn default() -> Self {
+        Self {
+            time: Some(TCP_KEEPALIVE_TIME),
+            interval: Some(TCP_KEEPALIVE_INTERVAL),
+        }
+    }
+}
+
+impl From<&KeepaliveOpts> for TcpKeepalive {
+    fn from(value: &KeepaliveOpts) -> Self {
+        let mut result = TcpKeepalive::new();
+        if let Some(time) = value.time {
+            result = result.with_time(time);
+        }
+        if let Some(interval) = value.interval {
+            result = result.with_interval(interval);
+        }
+        cfg_if::cfg_if! {
+            if #[cfg(not(windows))] {
+                if let Some(retries) = value.retries {
+                    result = result.with_retries(retries);
+                }
+            }
+        }
+        result
+    }
+}
+
+pub async fn stream<A: AsyncToSocketAddrs>(addr: A) -> Result<TcpStream, std::io::Error> {
+    let socket_opts = SocketOpts {
+        keepalive: Some(Default::default()),
+        ..Default::default()
     };
+    stream_with_opts(addr, Some(socket_opts)).await
+}
 
-    let client_ft = async {
-        debug!("client: sleep to give server chance to come up");
-        sleep(time::Duration::from_millis(100)).await;
-        debug!("client: trying to connect");
-        let tcp_stream = TcpStream::connect(&addr).await?;
-        let mut framed = Framed::new(tcp_stream.compat(), BytesCodec::new());
-        debug!("client: got connection. waiting");
-        let value = framed.next().await.expect("no value received");
-        debug!("client :received first value from server");
-        let bytes = value?;
-        debug!("client :received bytes len: {}", bytes.len());
-        assert_eq!(bytes.len(), 3);
-        let values = bytes.take(3).into_inner();
-        assert_eq!(values[0], 0x05);
-        assert_eq!(values[1], 0x0a);
-        assert_eq!(values[2], 0x63);
+pub async fn stream_with_opts<A: AsyncToSocketAddrs>(
+    addr: A,
+    socket_opts: Option<SocketOpts>,
+) -> Result<TcpStream, std::io::Error> {
+    debug!(?socket_opts);
+    let tcp_stream = TcpStream::connect(addr).await?;
+    if let Some(socket_opts) = socket_opts {
+        let socket_ref = SockRef::from(&tcp_stream);
+        if let Some(nodelay) = socket_opts.nodelay {
+            socket_ref.set_nodelay(nodelay)?;
+        }
+        if let Some(ref keepalive_opts) = socket_opts.keepalive {
+            let keepalive = TcpKeepalive::from(keepalive_opts);
+            socket_ref.set_tcp_keepalive(&keepalive)?;
+        }
+    }
+    Ok(tcp_stream)
+}
 
-        Ok(()) as Result<(), Error>
-    };
+#[cfg(test)]
+mod tests {
+    use std::io::Error;
 
-    let _ = zip(client_ft, server_ft).await;
+    use super::*;
+    use crate::test_async;
+    use crate::timer::sleep;
+    use async_net::SocketAddr;
+    use async_net::TcpListener;
+    use bytes::BufMut;
+    use bytes::Bytes;
+    use bytes::BytesMut;
+    use futures_lite::future::zip;
+    use futures_lite::AsyncReadExt;
+    use futures_util::SinkExt;
+    use futures_util::StreamExt;
+    use log::debug;
+    use tokio_util::codec::BytesCodec;
+    use tokio_util::codec::Framed;
+    use tokio_util::compat::FuturesAsyncReadCompatExt;
 
-    Ok(())
+    fn to_bytes(bytes: Vec<u8>) -> Bytes {
+        let mut buf = BytesMut::with_capacity(bytes.len());
+        buf.put_slice(&bytes);
+        buf.freeze()
+    }
+
+    #[test_async]
+    async fn test_async_tcp() -> Result<(), Error> {
+        let addr = "127.0.0.1:9998".parse::<SocketAddr>().expect("parse");
+
+        let server_ft = async {
+            debug!("server: binding");
+            let listener = TcpListener::bind(&addr).await?;
+            debug!("server: successfully binding. waiting for incoming");
+            let mut incoming = listener.incoming();
+            let stream = incoming.next().await.expect("no stream");
+            debug!("server: got connection from client");
+            let tcp_stream = stream?;
+            let mut framed = Framed::new(tcp_stream.compat(), BytesCodec::new());
+            debug!("server: sending values to client");
+            let data = vec![0x05, 0x0a, 0x63];
+            framed.send(to_bytes(data)).await?;
+            Ok(()) as Result<(), Error>
+        };
+
+        let client_ft = async {
+            debug!("client: sleep to give server chance to come up");
+            sleep(Duration::from_millis(100)).await;
+            debug!("client: trying to connect");
+            let tcp_stream = stream(&addr).await?;
+            let mut framed = Framed::new(tcp_stream.compat(), BytesCodec::new());
+            debug!("client: got connection. waiting");
+            let value = framed.next().await.expect("no value received");
+            debug!("client :received first value from server");
+            let bytes = value?;
+            debug!("client :received bytes len: {}", bytes.len());
+            assert_eq!(bytes.len(), 3);
+            let values = bytes.take(3).into_inner();
+            assert_eq!(values[0], 0x05);
+            assert_eq!(values[1], 0x0a);
+            assert_eq!(values[2], 0x63);
+
+            Ok(()) as Result<(), Error>
+        };
+
+        let _ = zip(client_ft, server_ft).await;
+
+        Ok(())
+    }
+
+    #[test_async]
+    async fn test_tcp_stream_socket_opts() -> Result<(), Error> {
+        let addr = "127.0.0.1:9997".parse::<SocketAddr>().expect("parse");
+
+        let server_ft = async {
+            debug!("server: binding");
+            let listener = TcpListener::bind(&addr).await?;
+            debug!("server: successfully binding. waiting for incoming");
+            let mut incoming = listener.incoming();
+            let _stream = incoming.next().await.expect("no stream");
+            let _stream = incoming.next().await.expect("no stream");
+            debug!("server: got connection from client");
+            Ok(()) as Result<(), Error>
+        };
+
+        let client_ft = async {
+            debug!("client: sleep to give server chance to come up");
+            sleep(Duration::from_millis(100)).await;
+            debug!("client: trying to connect");
+            {
+                let socket_opts = SocketOpts {
+                    keepalive: None,
+                    nodelay: Some(false),
+                };
+                let tcp_stream = stream_with_opts(&addr, Some(socket_opts)).await?;
+                assert!(!tcp_stream.nodelay()?);
+                let socket_ref = SockRef::from(&tcp_stream);
+                assert!(!(socket_ref.nodelay()?));
+                assert!(!(socket_ref.keepalive()?));
+            }
+            {
+                let time = Duration::from_secs(7201);
+                let interval = Duration::from_secs(76);
+                cfg_if::cfg_if! {
+                    if #[cfg(windows)] {
+                        let socket_opts = SocketOpts {
+                            keepalive: Some(KeepaliveOpts {
+                                time: Some(time),
+                                interval: Some(interval),
+                            }),
+                            nodelay: Some(true),
+                        };
+                    } else {
+                        let retries = 10;
+                        let socket_opts = SocketOpts {
+                            keepalive: Some(KeepaliveOpts {
+                                time: Some(time),
+                                interval: Some(interval),
+                                retries: Some(retries),
+                            }),
+                            nodelay: Some(true),
+                        };
+                    }
+                }
+
+                let tcp_stream = stream_with_opts(&addr, Some(socket_opts)).await?;
+                assert!(tcp_stream.nodelay()?);
+                let socket_ref = SockRef::from(&tcp_stream);
+                assert!(socket_ref.nodelay()?);
+                assert!(socket_ref.keepalive()?);
+                cfg_if::cfg_if! {
+                    if #[cfg(not(windows))] {
+                        assert_eq!(socket_ref.keepalive_time()?, time);
+                        assert_eq!(socket_ref.keepalive_interval()?, interval);
+                        assert_eq!(socket_ref.keepalive_retries()?, retries);
+                    }
+                }
+            }
+
+            Ok(()) as Result<(), Error>
+        };
+
+        let _ = zip(client_ft, server_ft).await;
+
+        Ok(())
+    }
 }

--- a/src/openssl/test.rs
+++ b/src/openssl/test.rs
@@ -13,7 +13,7 @@ use tokio_util::codec::BytesCodec;
 use tokio_util::codec::Framed;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 
-use crate::net::{TcpListener, TcpStream};
+use crate::net::{tcp_stream::stream, TcpListener};
 use crate::test_async;
 use crate::timer::sleep;
 
@@ -142,7 +142,7 @@ async fn run_test(acceptor: TlsAcceptor, connector: TlsConnector) -> Result<(), 
         debug!("client: sleep to give server chance to come up");
         sleep(time::Duration::from_millis(100)).await;
         debug!("client: trying to connect");
-        let tcp_stream = TcpStream::connect(&addr).await.expect("connection fail");
+        let tcp_stream = stream(&addr).await.expect("connection fail");
         let tls_stream = connector
             .connect("localhost", tcp_stream)
             .await

--- a/src/zero_copy.rs
+++ b/src/zero_copy.rs
@@ -197,8 +197,8 @@ mod tests {
 
     use crate::file_slice::AsyncFileSlice;
     use crate::fs::AsyncFileExtension;
+    use crate::net::tcp_stream::stream;
     use crate::net::TcpListener;
-    use crate::net::TcpStream;
     use crate::timer::sleep;
     use crate::{fs::util as file_util, zero_copy::ZeroCopy};
     use futures_lite::AsyncReadExt;
@@ -234,7 +234,7 @@ mod tests {
             sleep(time::Duration::from_millis(100)).await;
 
             debug!("client: file loaded");
-            let mut stream = TcpStream::connect(&addr).await?;
+            let mut stream = stream(&addr).await?;
             debug!("client: connected to server");
             let f_slice = file.as_slice(0, None).await?;
             debug!("client: send back file using zero copy");
@@ -323,7 +323,7 @@ mod tests {
 
             for i in 0..TEST_ITERATION {
                 debug!("client: Test loop: {}", i);
-                let mut stream = TcpStream::connect(&addr).await?;
+                let mut stream = stream(&addr).await?;
                 debug!("client: {} connected trying to read", i);
                 // let server send response
 
@@ -378,7 +378,7 @@ mod tests {
             sleep(time::Duration::from_millis(100)).await;
 
             debug!("client: file loaded");
-            let mut stream = TcpStream::connect(&addr).await?;
+            let mut stream = stream(&addr).await?;
             debug!("client: connected to server");
             let f_slice = file.as_slice(0, None).await?;
             let max_slice = AsyncFileSlice::new(f_slice.fd(), 0, 1000);


### PR DESCRIPTION
Added an ability to set socket `keepalive` property.

By default, all fluvio TCP connections will have set `keepalive=true`.  This is needed to prevent silently closing TCP connections by OS or network gateways when there is no traffic for an extended period of time. It often happens for consumers when there is no data on the topic for a period of more than one day. TCP session gets closed but the consumer does not determine that and keeps waiting for the data. For instance https://github.com/infinyon/roadmap/issues/85