### PR TITLE
chore: downgrade  openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-future"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "I/O futures for Fluvio project"
@@ -56,7 +56,7 @@ futures-rustls = { version = "0.26.0", optional = true }
 memmap2 = { version = "0.9.5", optional = true }
 native-tls = { version = "0.2.14", optional = true }
 nix = { version = "0.30.1", optional = true, features = ["zerocopy"] }
-openssl = { version = "0.10.73", optional = true }
+openssl = { version = "0.10.71", optional = true }
 openssl-sys = { version = "0.9.109", optional = true, features = ["vendored"] }
 rustls-pemfile = { version = "2.2", optional = true }
 socket2 = { version = "0.5.10", default-features = false, features = ["all"], optional = true }


### PR DESCRIPTION
Got this issue https://github.com/infinyon/fluvio/issues/4502 using that openssl version